### PR TITLE
use npm package of realms-shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Caridy Patiño <caridy@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "realms-shim": "github:Agoric/realms-shim"
+    "realms-shim": "^1.1.2"
   },
   "devDependencies": {
     "@zoltu/typescript-transformer-append-js-extension": "^1.0.1",


### PR DESCRIPTION
This PR fixes the `yarn build` command by using the npm package of `realms-shim` (avoids needing to `npm link` etc)