### PR TITLE
Avoid prototype lookups to .call()

### DIFF
--- a/src/reverse-proxy-handler.ts
+++ b/src/reverse-proxy-handler.ts
@@ -1,4 +1,6 @@
 import {
+    apply,
+    construct,
     isUndefined,
     ObjectDefineProperty,
     setPrototypeOf,
@@ -92,7 +94,7 @@ export class ReverseProxyHandler implements ProxyHandler<ReverseProxyTarget> {
         const { target, env } = this;
         const secThisArg = env.getSecureValue(thisArg);
         const secArgArray = env.getSecureArray(argArray);
-        const sec = Reflect.apply(target as SecureFunction, secThisArg, secArgArray);
+        const sec = apply(target as SecureFunction, secThisArg, secArgArray);
         return env.getRawValue(sec) as RawValue;
     }
     construct(shadowTarget: ReverseShadowTarget, argArray: RawValue[], newTarget: RawObject): RawObject {
@@ -102,7 +104,7 @@ export class ReverseProxyHandler implements ProxyHandler<ReverseProxyTarget> {
         }
         const secArgArray = env.getSecureArray(argArray);
         // const secNewTarget = env.getSecureValue(newTarget);
-        const sec = Reflect.construct(SecCtor as SecureConstructor, secArgArray);
+        const sec = construct(SecCtor as SecureConstructor, secArgArray);
         const raw = env.getRawValue(sec);
         return raw as RawObject;
     }

--- a/src/secure-proxy-handler.ts
+++ b/src/secure-proxy-handler.ts
@@ -1,4 +1,6 @@
 import {
+    apply,
+    construct,
     isUndefined,
     ObjectDefineProperty,
     setPrototypeOf,
@@ -119,7 +121,7 @@ export class SecureProxyHandler implements ProxyHandler<SecureProxyTarget> {
             // this.target is already in registered in the map, which means it
             // will always return a valid secure object without having to create it.
             const sec = this.env.getSecureValue(this.target);
-            return Reflect.apply(get, sec, []);
+            return apply(get, sec, []);
         }
         return desc.value;
     }
@@ -151,7 +153,7 @@ export class SecureProxyHandler implements ProxyHandler<SecureProxyTarget> {
                 // this.target is already in registered in the map, which means it
                 // will always return a valid secure object without having to create it.
                 const sec = this.env.getSecureValue(this.target);
-                Reflect.apply(set, sec, [value]);
+                apply(set, sec, [value]);
             } else if (!isUndefined(get)) {
                 // a getter without a setter should fail to set in strict mode
                 // TypeError: Cannot set property ${key} of object which has only a getter
@@ -173,7 +175,7 @@ export class SecureProxyHandler implements ProxyHandler<SecureProxyTarget> {
         this.initialize(shadowTarget);
         const rawThisArg = env.getRawValue(thisArg);
         const rawArgArray = env.getRawArray(argArray);
-        const raw = Reflect.apply(target as RawFunction, rawThisArg, rawArgArray);
+        const raw = apply(target as RawFunction, rawThisArg, rawArgArray);
         return env.getSecureValue(raw) as SecureValue;
     }
     construct(shadowTarget: SecureShadowTarget, argArray: SecureValue[], newTarget: SecureObject): SecureObject {
@@ -184,7 +186,7 @@ export class SecureProxyHandler implements ProxyHandler<SecureProxyTarget> {
         }
         const rawArgArray = env.getRawArray(argArray);
         const rawNewTarget = env.getRawValue(newTarget);
-        const raw = Reflect.construct(RawCtor as RawConstructor, rawArgArray, rawNewTarget);
+        const raw = construct(RawCtor as RawConstructor, rawArgArray, rawNewTarget);
         const sec = env.getSecureValue(raw);
         return sec as SecureObject;
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,19 +1,27 @@
 const {
-    getPrototypeOf,
-    setPrototypeOf,
     create: ObjectCreate,
-    defineProperty: ObjectDefineProperty,
-    isExtensible,
-    getOwnPropertyDescriptor,
     getOwnPropertyDescriptors,
     getOwnPropertyNames,
     getOwnPropertySymbols,
-    preventExtensions,
-    hasOwnProperty,
     freeze,
 } = Object;
 
+const {
+    apply,
+    construct,
+    getPrototypeOf,
+    setPrototypeOf,
+    defineProperty: ObjectDefineProperty,
+    isExtensible,
+    getOwnPropertyDescriptor,
+    preventExtensions,
+} = Reflect;
+
+const hasOwnProperty = unapply(Object.prototype.hasOwnProperty);
+
 export {
+    apply,
+    construct,
     getPrototypeOf,
     setPrototypeOf,
     ObjectCreate,
@@ -27,6 +35,10 @@ export {
     hasOwnProperty,
     freeze,
 };
+
+export function unapply(func: Function): Function {
+    return (thisArg: any, ...args: any[]) => apply(func, thisArg, args);
+}
 
 export function isUndefined(obj: any): obj is undefined {
     return obj === undefined;


### PR DESCRIPTION
This PR adds some utils to avoid prototype lookups of `.call()` and `.apply()`.
This also uses some of the `Reflect` flavors of methods because they are more forgiving in terms of errors being thrown in many cases (just a preference).