### PR TITLE
baby step into sandbox attribute use for browser-realm

### DIFF
--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -6,6 +6,7 @@ const unsafeGlobalSrc = "'use strict'; this";
 export default function createSecureEnvironment(distortionCallback: (target: SecureProxyTarget) => SecureProxyTarget) {
     // @ts-ignore document global ref - in browsers
     const iframe = document.createElement('iframe');
+    iframe.sandbox = 'allow-same-origin allow-scripts';
     iframe.style.display = 'none';
 
     // @ts-ignore document global ref - in browsers


### PR DESCRIPTION
This just adds a basic sandbox attribute to treat it as same origin and allow script execution. This has a bonus of preventing `window.top.location = ...` changes and a few other things that are all off-by-default. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) for the rest of the off-by-default things. A follow-up would be to use the [allow](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allow) attribute as well to [disable things like setting `document.domain`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#Directives) when support lands more broadly (many of them are behind flags or not yet supported by Chrome and others).