### PR TITLE
null the prototype of proxy handlers

### DIFF
--- a/src/reverse-proxy-handler.ts
+++ b/src/reverse-proxy-handler.ts
@@ -145,3 +145,5 @@ export class ReverseProxyHandler implements ProxyHandler<ReverseProxyTarget> {
         return false; // reverse proxies are immutable
     }
 }
+
+setPrototypeOf(ReverseProxyHandler.prototype, null);

--- a/src/secure-proxy-handler.ts
+++ b/src/secure-proxy-handler.ts
@@ -236,3 +236,5 @@ export class SecureProxyHandler implements ProxyHandler<SecureProxyTarget> {
         return true;
     }
 }
+
+setPrototypeOf(SecureProxyHandler.prototype, null);


### PR DESCRIPTION
Proxies will walk the prototype of their handlers looking for traps. This prevents them from prototype pollution.