### PR TITLE
add missing hasOwnProperty() checks

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -166,7 +166,7 @@ export class SecureEnvironment {
 
     remap(secureValue: SecureValue, rawValue: RawValue, rawDescriptors: PropertyDescriptorMap) {
         this.createSecureRecord(secureValue, rawValue);
-        for (let key in rawDescriptors) {
+        for (const key in rawDescriptors) {
             // TODO: this whole block needs cleanup and simplification
             // avoid overriding ecma script global keys.
             if (!ESGlobalKeys.has(key)) {
@@ -192,7 +192,9 @@ export class SecureEnvironment {
                         // we don't pay the cost of creating the proxy in the first place
                         rawDescriptor.value = this.getSecureValue(rawDescriptorValue);
                     }
-                    if (!isUndefined(secureDescriptor) && secureDescriptor.configurable === false) {
+                    if (!isUndefined(secureDescriptor) && 
+                            hasOwnProperty(secureDescriptor, 'configurable') &&  
+                            secureDescriptor.configurable === false) {
                         // this is the case where the secure env has a descriptor that was supposed to be
                         // overrule but can't be done because it is a non-configurable. Instead we try to
                         // fallback to some more advanced gymnastics

--- a/src/reverse-proxy-handler.ts
+++ b/src/reverse-proxy-handler.ts
@@ -54,7 +54,8 @@ function copyReverseOwnDescriptors(env: SecureEnvironment, shadowTarget: Reverse
             originalDescriptor = getReverseDescriptor(originalDescriptor, env);
             const shadowTargetDescriptor = getOwnPropertyDescriptor(shadowTarget, key);
             if (!isUndefined(shadowTargetDescriptor)) {
-                if (isTrue(shadowTargetDescriptor.configurable)) {
+                if (hasOwnProperty(shadowTargetDescriptor, 'configurable') &&
+                        isTrue(shadowTargetDescriptor.configurable)) {
                     ObjectDefineProperty(shadowTarget, key, originalDescriptor);
                 } else if (isTrue(shadowTargetDescriptor.writable)) {
                     // just in case

--- a/src/secure-proxy-handler.ts
+++ b/src/secure-proxy-handler.ts
@@ -67,9 +67,11 @@ function copySecureOwnDescriptors(env: SecureEnvironment, shadowTarget: SecureSh
             originalDescriptor = getSecureDescriptor(originalDescriptor, env);
             const shadowTargetDescriptor = getOwnPropertyDescriptor(shadowTarget, key);
             if (!isUndefined(shadowTargetDescriptor)) {
-                if (isTrue(shadowTargetDescriptor.configurable)) {
+                if (hasOwnProperty(shadowTargetDescriptor, 'configurable') &&
+                        isTrue(shadowTargetDescriptor.configurable)) {
                     ObjectDefineProperty(shadowTarget, key, originalDescriptor);
-                } else if (isTrue(shadowTargetDescriptor.writable)) {
+                } else if (hasOwnProperty(shadowTargetDescriptor, 'writable') &&
+                        isTrue(shadowTargetDescriptor.writable)) {
                     // just in case
                     shadowTarget[key] = originalDescriptor.value;
                 } else {


### PR DESCRIPTION
Add some missing hasOwnProperty checks to descriptors. Feel free to nit the styling wasn't sure about line length (linting with `--fix` will eventually fix these).