### PR TITLE
avoid spread operator side effects [closes #13]

### DIFF
--- a/src/reverse-proxy-handler.ts
+++ b/src/reverse-proxy-handler.ts
@@ -13,6 +13,7 @@ import {
     isFunction,
     isTrue,
     hasOwnProperty,
+    push,
 } from './shared';
 import {
     SecureEnvironment,
@@ -119,11 +120,10 @@ export class ReverseProxyHandler implements ProxyHandler<ReverseProxyTarget> {
         return key in shadowTarget;
     }
     ownKeys(shadowTarget: ReverseShadowTarget): (string | symbol)[] {
-        // TODO: avoid triggering the iterator protocol
-        return [
-            ...getOwnPropertyNames(shadowTarget),
-            ...getOwnPropertySymbols(shadowTarget),
-        ];
+        return push(
+            getOwnPropertyNames(shadowTarget),
+            getOwnPropertySymbols(shadowTarget)
+        );
     }
     getOwnPropertyDescriptor(shadowTarget: ReverseShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
         return getOwnPropertyDescriptor(shadowTarget, key);

--- a/src/secure-proxy-handler.ts
+++ b/src/secure-proxy-handler.ts
@@ -19,6 +19,7 @@ import {
     isSealed,
     isFrozen,
     seal,
+    push,
 } from './shared';
 import {
     SecureEnvironment,
@@ -208,11 +209,10 @@ export class SecureProxyHandler implements ProxyHandler<SecureProxyTarget> {
     }
     ownKeys(shadowTarget: SecureShadowTarget): (string | symbol)[] {
         this.initialize(shadowTarget);
-        // TODO: this is leaking outer realm's array
-        return [
-            ...getOwnPropertyNames(shadowTarget),
-            ...getOwnPropertySymbols(shadowTarget),
-        ];
+        return push(
+            getOwnPropertyNames(shadowTarget),
+            getOwnPropertySymbols(shadowTarget)
+        );
     }
     isExtensible(shadowTarget: SecureShadowTarget): boolean {
         this.initialize(shadowTarget);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -24,6 +24,7 @@ const {
 
 const hasOwnProperty = unapply(Object.prototype.hasOwnProperty);
 const map = unapply(Array.prototype.map);
+const push = unapply(Array.prototype.push);
 
 export {
     apply,
@@ -42,6 +43,7 @@ export {
     freeze,
     isArray,
     map,
+    push,
     seal,
     isSealed,
     isFrozen,


### PR DESCRIPTION
This changes the two places using spread too just use `push` instead.