### PR TITLE
remove forced unwrap of Function and Object

### DIFF
--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -53,7 +53,6 @@ export default function createSecureEnvironment(distortionCallback: (target: Sec
     delete rawGlobalThisDescriptors.window;
 
     const env = new SecureEnvironment({
-        rawGlobalThis,
         secureGlobalThis,
         distortionCallback,
     });

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -14,7 +14,6 @@ export default function createSecureEnvironment(distortionCallback: (target: Sec
     const rawGlobalThis = globalThis as any;
     const rawGlobalThisDescriptors = getOwnPropertyDescriptors(rawGlobalThis);
     const env = new SecureEnvironment({
-        rawGlobalThis,
         secureGlobalThis,
         distortionCallback,
     });

--- a/src/secure-proxy-handler.ts
+++ b/src/secure-proxy-handler.ts
@@ -105,8 +105,8 @@ export class SecureProxyHandler implements ProxyHandler<SecureProxyTarget> {
     private readonly env: SecureEnvironment;
 
     constructor(env: SecureEnvironment, target: SecureProxyTarget) {
-        this.target = target;
         this.env = env;
+        this.target = target;
     }
     // initialization used to avoid the initialization cost
     // of an object graph, we want to do it when the

--- a/src/shim-realm.ts
+++ b/src/shim-realm.ts
@@ -11,7 +11,6 @@ export default function createSecureEnvironment(distortionCallback: (target: Sec
     const rawGlobalThisDescriptors = getOwnPropertyDescriptors(rawGlobalThis);
 
     const env = new SecureEnvironment({
-        rawGlobalThis,
         secureGlobalThis,
         distortionCallback,
     });


### PR DESCRIPTION
This PR addresses the following TODO:
> TODO: revisit this, is this really needed? what happen if Object.prototype is patched in the sec env?

I went ahead and removed it to simplify explanation of the membrane process and to see if it's really needed (things seem to continue to work).