### PR TITLE
scripts - build - complete typescript compile before bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "module": "lib/index.js",
   "types": "types/index.js",
   "scripts": {
-    "build": "ttsc & rollup -c",
+    "build": "ttsc && rollup -c",
     "start": "ttsc -w & http-server",
     "test": "jest --runInBand --no-cache --config ./jest.config.js",
     "publish": "npm publish --access public"


### PR DESCRIPTION
Fixes #40 
race condition with `ttsc` and `rollup` due to not waiting for completion