### PR TITLE
fixes #8: basic implementation of the error boundaries

### DIFF
--- a/src/__tests__/error.spec.ts
+++ b/src/__tests__/error.spec.ts
@@ -4,6 +4,8 @@ function throwNewError(Ctor, msg) {
     throw new Ctor(msg);
 }
 
+let sandboxedFn;
+
 globalThis.foo = {
     set a(v) {
         throwNewError(Error, 'a() setter throws for argument: ' + v);
@@ -14,19 +16,25 @@ globalThis.foo = {
     b(v) {
         throwNewError(RangeError, 'b() method throws for argument: ' + v);
     },
+    expose(fn) {
+        sandboxedFn = fn;
+    }
 };
 
 describe('The Error Boundary', () => {
     it('should preserve identity of errors after a membrane roundtrip', function() {
         const secureGlobalThis = createSecureEnvironment((v) => v);
+        secureGlobalThis.eval(`foo.expose(() => { foo.a })`);
         expect(() => {
-            secureGlobalThis.eval(`foo.a;`);
+            sandboxedFn();
         }).toThrowError(Error);
+        secureGlobalThis.eval(`foo.expose(() => { foo.a = 1; })`);
         expect(() => {
-            secureGlobalThis.eval(`foo.a = 1;`);
+            sandboxedFn();
         }).toThrowError(Error);
+        secureGlobalThis.eval(`foo.expose(() => { foo.b(2); })`);
         expect(() => {
-            secureGlobalThis.eval(`foo.b(2);`);
+            sandboxedFn();
         }).toThrowError(RangeError);
     });
     it('should remap the Outer Realm Error instance to the sandbox errors', function() {
@@ -44,25 +52,25 @@ describe('The Error Boundary', () => {
         }).not.toThrowError();
         expect(() => {
             secureGlobalThis.eval(`
-            try {
-                foo.a = 1;
-            } catch (e) {
-                if (!(e instanceof Error)) {
-                    throw new Error('Invalid Error Identity');
+                try {
+                    foo.a = 1;
+                } catch (e) {
+                    if (!(e instanceof Error)) {
+                        throw new Error('Invalid Error Identity');
+                    }
                 }
-            }
-        `);
+            `);
         }).not.toThrowError();
         expect(() => {
             secureGlobalThis.eval(`
-            try {
-                foo.b(2);
-            } catch (e) {
-                if (!(e instanceof RangeError)) {
-                    throw new Error('Invalid Error Identity');
+                try {
+                    foo.b(2);
+                } catch (e) {
+                    if (!(e instanceof RangeError)) {
+                        throw new Error('Invalid Error Identity');
+                    }
                 }
-            }
-        `);
+            `);
         }).not.toThrowError();
     });
 });

--- a/src/__tests__/reflection.spec.ts
+++ b/src/__tests__/reflection.spec.ts
@@ -1,0 +1,51 @@
+import createSecureEnvironment from '../node-realm';
+
+globalThis.foo = {
+    b() {},
+    e: new Error(),
+};
+
+describe('Reflective Intrinsic Objects', () => {
+    it('should preserve identity of Object thru membrane', function() {
+        const secureGlobalThis = createSecureEnvironment((v) => v);
+        expect(() => {
+            secureGlobalThis.eval(`
+                if (!(foo instanceof Object)) {
+                    throw new Error('Invalid Identity of foo');
+                }
+                const o = {};
+                if (!(o instanceof Object)) {
+                    throw new Error('Invalid Identity of o');
+                }
+            `);
+        }).not.toThrowError();
+    });
+    it('should preserve identity of Function thru membrane', function() {
+        const secureGlobalThis = createSecureEnvironment((v) => v);
+        expect(() => {
+            secureGlobalThis.eval(`
+                if (!(foo.b instanceof Function)) {
+                    throw new Error('Invalid Identity of foo.b');
+                }
+                function x() {}
+                if (!(x instanceof Function)) {
+                    throw new Error('Invalid Identity of x');
+                }
+            `);
+        }).not.toThrowError();
+    });
+    it('should preserve identity of Error thru membrane', function() {
+        const secureGlobalThis = createSecureEnvironment((v) => v);
+        expect(() => {
+            secureGlobalThis.eval(`
+                if (!(foo.e instanceof Error)) {
+                    throw new Error('Invalid Identity of foo.e');
+                }
+                const e = new Error();
+                if (!(e instanceof Error)) {
+                    throw new Error('Invalid Identity of e');
+                }
+            `);
+        }).not.toThrowError();
+    });
+});

--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -1,4 +1,5 @@
-import { SecureEnvironment, SecureProxyTarget } from "./environment";
+import { SecureEnvironment } from "./environment";
+import { SecureProxyTarget } from "./membrane";
 import { 
     ReflectGetPrototypeOf, 
     ReflectSetPrototypeOf, 

--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -30,7 +30,7 @@ export default function createSecureEnvironment(distortionCallback: (target: Sec
     // In Chrome debugger statements will be ignored when the iframe is removed
     // from the document. Other browsers like Firefox and Safari work as expected.
     // https://bugs.chromium.org/p/chromium/issues/detail?id=1015462
-    // iframe.remove();
+    iframe.remove();
 
     // window -> Window -> WindowProperties -> EventTarget
     const secureDocument = secureWindow.document;

--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -30,7 +30,7 @@ export default function createSecureEnvironment(distortionCallback: (target: Sec
     // In Chrome debugger statements will be ignored when the iframe is removed
     // from the document. Other browsers like Firefox and Safari work as expected.
     // https://bugs.chromium.org/p/chromium/issues/detail?id=1015462
-    iframe.remove();
+    // iframe.remove();
 
     // window -> Window -> WindowProperties -> EventTarget
     const secureDocument = secureWindow.document;

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -137,6 +137,9 @@ export class SecureEnvironment {
         return shadowTarget;
     }
     private createSecureProxy(raw: SecureProxyTarget): SecureProxy {
+        if (this.som.has(raw)) {
+            throw new Error('Invariant Violation');
+        }
         const shadowTarget = this.createSecureShadowTarget(raw);
         const proxyHandler = new SecureProxyHandler(this, raw);
         const sec = this.createProxyInSandbox(shadowTarget, proxyHandler);
@@ -144,6 +147,9 @@ export class SecureEnvironment {
         return sec;
     }
     private createReverseProxy(sec: ReverseProxyTarget): ReverseProxy {
+        if (this.rom.has(sec)) {
+            throw new Error('Invariant Violation');
+        }
         const shadowTarget = this.createReverseShadowTarget(sec);
         const proxyHandler = new ReverseProxyHandler(this, sec);
         const raw = ProxyCreate(shadowTarget, proxyHandler);

--- a/src/membrane.ts
+++ b/src/membrane.ts
@@ -1,0 +1,116 @@
+import {
+    isUndefined,
+    ObjectCreate,
+    ReflectGetPrototypeOf,
+    isFrozen,
+    isSealed,
+    ReflectIsExtensible,
+    getOwnPropertyDescriptors,
+    ReflectGetOwnPropertyDescriptor,
+    hasOwnProperty,
+    isTrue,
+    isFunction,
+    ReflectDefineProperty,
+} from "./shared";
+
+export type RawValue = any;
+export type RawArray = RawValue[];
+export type RawFunction = (...args: RawValue[]) => RawValue;
+export type RawObject = object;
+export interface RawConstructor {
+    new(...args: any[]): RawObject;
+}
+export type SecureProxyTarget = RawObject | RawFunction | RawConstructor;
+export type ReverseProxyTarget = SecureObject | SecureFunction | SecureConstructor;
+// TODO: how to doc the ProxyOf<>
+export type SecureShadowTarget = SecureProxyTarget; // Proxy<SecureProxyTarget>;
+export type ReverseShadowTarget = ReverseProxyTarget; // Proxy<ReverseProxyTarget>;
+
+export type SecureValue = any;
+export type SecureFunction = (...args: SecureValue[]) => SecureValue;
+export type SecureArray = SecureValue[];
+export type SecureObject = object;
+export interface SecureConstructor {
+    new(...args: any[]): SecureObject;
+}
+
+export interface TargetMeta {
+    proto: null | SecureProxyTarget | ReverseProxyTarget;
+    descriptors: PropertyDescriptorMap;
+    isFrozen?: true;
+    isSealed?: true;
+    isExtensible?: true;
+    isBroken?: true;
+}
+
+export function getTargetMeta(target: SecureProxyTarget | ReverseProxyTarget): TargetMeta {
+    const meta: TargetMeta = ObjectCreate(null);
+    try {
+        // a revoked proxy will break the membrane when reading the meta
+        meta.proto = ReflectGetPrototypeOf(target);
+        meta.descriptors = getOwnPropertyDescriptors(target);
+        if (isFrozen(target)) {
+            meta.isFrozen = meta.isSealed = meta.isExtensible = true;
+        } else if (isSealed(target)) {
+            meta.isSealed = meta.isExtensible = true;
+        } else if (ReflectIsExtensible(target)) {
+            meta.isExtensible = true;
+        }
+    } catch (_ignored) {
+        // intentionally swallowing the error because this method is just extracting the metadata
+        // in a way that it should always succeed except for the cases in which the target is a proxy
+        // that is either revoked or has some logic that is incompatible with the membrane, in which
+        // case we will just create the proxy for the membrane but revoke it right after to prevent
+        // any leakage.
+        meta.proto = null;
+        meta.descriptors = {};
+        meta.isBroken = true;
+    }
+    return meta;
+}
+
+export function installDescriptorIntoShadowTarget(shadowTarget: SecureProxyTarget | ReverseProxyTarget, key: PropertyKey, originalDescriptor: PropertyDescriptor) {
+    const shadowTargetDescriptor = ReflectGetOwnPropertyDescriptor(shadowTarget, key);
+    if (!isUndefined(shadowTargetDescriptor)) {
+        if (hasOwnProperty(shadowTargetDescriptor, 'configurable') &&
+                isTrue(shadowTargetDescriptor.configurable)) {
+            ReflectDefineProperty(shadowTarget, key, originalDescriptor);
+        } else if (hasOwnProperty(shadowTargetDescriptor, 'writable') &&
+                isTrue(shadowTargetDescriptor.writable)) {
+            // just in case
+            shadowTarget[key] = originalDescriptor.value;
+        } else {
+            // ignoring... since it is non configurable and non-writable
+            // usually, arguments, callee, etc.
+        }
+    } else {
+        ReflectDefineProperty(shadowTarget, key, originalDescriptor);
+    }
+}
+
+export function createShadowTarget(o: SecureProxyTarget): SecureShadowTarget
+export function createShadowTarget(target: ReverseProxyTarget): ReverseShadowTarget {
+    let shadowTarget;
+    if (isFunction(target)) {
+        shadowTarget = function () {};
+        let nameDescriptor: PropertyDescriptor | undefined;
+        try {
+            // a revoked proxy will break the membrane when reading the function name
+            nameDescriptor = ReflectGetOwnPropertyDescriptor(target, 'name');
+        } catch (_ignored) {
+            // intentionally swallowing the error because this method is just extracting the function
+            // in a way that it should always succeed except for the cases in which the target is a proxy
+            // that is either revoked or has some logic to prevent reading the name property descriptor.
+            // If it is revoked, it will be handled by the getTargetMeta() at some point, else, we just
+            // assume no name will be exposed, and continue.
+            // TODO: is the ignore name logic good enough? or should we be more restrictive?
+        }
+        if (!isUndefined(nameDescriptor)) {
+            ReflectDefineProperty(shadowTarget, 'name', nameDescriptor);
+        }
+    } else {
+        // o is object
+        shadowTarget = {};
+    }
+    return shadowTarget;
+}

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -1,4 +1,5 @@
-import { SecureEnvironment, SecureProxyTarget } from "./environment";
+import { SecureEnvironment } from "./environment";
+import { SecureProxyTarget } from "./membrane";
 import { getOwnPropertyDescriptors } from "./shared";
 import { runInNewContext } from 'vm';
 

--- a/src/reverse-proxy-handler.ts
+++ b/src/reverse-proxy-handler.ts
@@ -62,10 +62,10 @@ function callWithErrorBoundaryProtection(env: SecureEnvironment, fn: () => RawVa
         }
         let rawError;
         try {
-            rawError = new (env.getRawValue(e.constructor))(e.message);
+            rawError = construct(env.getRawValue(e.constructor), [e.message]);
         } catch (ignored) {
             // in case the constructor inference fails
-            rawError = new Error(e.message)
+            rawError = construct(Error, [e.message]);
         }
         // by throwing a new raw error, we eliminate the stack information from the sandbox
         throw rawError;

--- a/src/secure-proxy-handler.ts
+++ b/src/secure-proxy-handler.ts
@@ -123,7 +123,7 @@ export class SecureProxyHandler implements ProxyHandler<SecureProxyTarget> {
         // once the initialization is executed once... the rest is just noop 
         this.initialize = noop;
         // adjusting the proto chain of the shadowTarget (recursively)
-        const secProto =  env.getSecureValue(meta.proto);
+        const secProto = env.getSecureValue(meta.proto);
         ReflectSetPrototypeOf(shadowTarget, secProto);
         // defining own descriptors
         copySecureOwnDescriptors(env, shadowTarget, meta.descriptors);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -3,7 +3,6 @@ const { isArray } = Array;
 const {
     assign,
     create: ObjectCreate,
-    defineProperty: ObjectDefineProperty,
     getOwnPropertyDescriptors,
     freeze,
     seal,
@@ -44,7 +43,6 @@ export {
     ReflectGetPrototypeOf,
     ReflectSetPrototypeOf,
     ObjectCreate,
-    ObjectDefineProperty,
     ProxyCreate,
     ReflectDefineProperty,
     ReflectIsExtensible,

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -3,6 +3,7 @@ const { isArray: ArrayIsArray } = Array;
 const {
     assign,
     create: ObjectCreate,
+    defineProperty: ObjectDefineProperty,
     getOwnPropertyDescriptors,
     freeze,
     seal,
@@ -43,6 +44,7 @@ export {
     ReflectGetPrototypeOf,
     ReflectSetPrototypeOf,
     ObjectCreate,
+    ObjectDefineProperty,
     ProxyRevocable,
     ReflectDefineProperty,
     ReflectIsExtensible,

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -154,3 +154,17 @@ export const ESGlobalKeys = SetCreate([
     // *** ECMA-402
     'Intl', // Unstable
 ]);
+
+// These are foundational things that should never be wrapped but are equivalent
+// TODO: revisit this list.
+export const ReflectiveIntrinsicObjectNames = [
+    'Object',
+    'Function',
+    'URIError',
+    'TypeError',
+    'SyntaxError',
+    'ReferenceError',
+    'RangeError',
+    'EvalError',
+    'Error',
+];

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -83,21 +83,6 @@ export function isRevokedProxy(a: any): boolean {
     }
 }
 
-interface AConstructor {
-    new(...args: any[]): unknown;
-}
-
-type AFunction = (...args: unknown[]) => unknown
-
-export function getFunctionName(fn: AConstructor | AFunction): string {
-    try {
-        // a revoked proxy will break the membrane when reading the function name
-        return fn.name;
-    } catch (_ignored) {
-        return ''; // or maybe undefined
-    }
-}
-
 export function unapply(func: Function): Function {
     return (thisArg: any, ...args: any[]) => apply(func, thisArg, args);
 }


### PR DESCRIPTION
This PR identifies areas where:

* a sandbox calls into the outer realm which might throw.
* a membrane procedure throws an error.
* proxy and array for the sandbox should be from the sandbox intrinsics.
* remapping all intrinsic error constructors between the two realms.
* abstraction membrane operations and types into its own file.
* revoked or broken targets should be represented via a revoked proxy.
* extracting target meta during proxy construction to avoid leaking mutations before the initialization of the secure proxy.
