### PR TITLE
Added isNullish shared utility

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -2,6 +2,7 @@ import {
     apply, 
     assign,
     isUndefined, 
+    isNullish,
     ObjectCreate, 
     isFunction, 
     hasOwnProperty, 
@@ -56,7 +57,7 @@ interface SecureRecord {
 function isProxyTarget(o: RawValue | SecureValue):
     o is (RawFunction | RawConstructor | RawObject | SecureFunction | SecureConstructor | SecureObject) {
     // hire-wired for the common case
-    if (o == null) {
+    if (isNullish(o)) {
         return false;
     }
     const t = typeof o;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -79,6 +79,11 @@ export function isUndefined(obj: any): obj is undefined {
     return obj === undefined;
 }
 
+export function isNullish(obj: any): obj is null {
+    // eslint-disable-next-line eqeqeq
+    return obj == null;
+}
+
 export function isTrue(obj: any): obj is true {
     return obj === true;
 }


### PR DESCRIPTION
To avoid confusion whether our use of `==` is intentional.
Also disable eslint rule just in case and for clarity.