### PR TITLE
Error Boundary: avoid leaking globals from sandbox

### DIFF
--- a/examples/custom-elements.js
+++ b/examples/custom-elements.js
@@ -1,13 +1,13 @@
 import createSecureEnvironment from '../lib/browser-realm.js';
 
-const secureGlobalThis = createSecureEnvironment();
+const evalScript = createSecureEnvironment();
 
 // listening for x from outer realm
 document.body.addEventListener('x', function (e) {
     console.log(e, e.target, e.currentTarget);
 });
 
-secureGlobalThis.eval(`
+evalScript(`
     debugger;
 
     // custom elements

--- a/examples/custom-events.js
+++ b/examples/custom-events.js
@@ -1,13 +1,13 @@
 import createSecureEnvironment from '../lib/browser-realm.js';
 
-const secureGlobalThis = createSecureEnvironment();
+const evalScript = createSecureEnvironment();
 
 // listening for x from outer realm
 document.body.addEventListener('x', function (e) {
     console.log(e, e.target, e.currentTarget);
 });
 
-secureGlobalThis.eval(`
+evalScript(`
     debugger;
 
     const elm = document.createElement('p');

--- a/examples/errors.html
+++ b/examples/errors.html
@@ -1,0 +1,7 @@
+<html>
+    <head>
+    </head>
+    <body>
+        <script type="module" src="./errors.js"></script>
+    </body>
+</html>

--- a/examples/errors.js
+++ b/examples/errors.js
@@ -1,0 +1,79 @@
+import createSecureEnvironment from '../lib/browser-realm.js';
+
+const distortionMap = new Map([
+    [alert, () => {
+        console.error('forbidden');
+    }],
+]);
+
+globalThis.bar = { a: 1, b: 2 };
+Object.freeze(globalThis.bar)
+
+const evalScript = createSecureEnvironment(distortionMap);
+
+try {
+    evalScript(`
+        return; // illegal return statement
+    `);
+} catch (e) {
+    // testing syntax error when evaluating
+    e instanceof SyntaxError;
+}
+
+try {
+    evalScript(`
+        throw new Error('test');
+    `);
+} catch (e) {
+    // testing initialization error when evaluating
+    e instanceof Error;
+}
+
+// verifying that in deep it is reflected as frozen
+evalScript(`
+    'use strict';
+    try {
+        bar.c = 3; // because it is frozen
+    } catch (e) {
+        e instanceof TypeError;
+    }
+    bar.c === undefined;
+`);
+
+
+evalScript(`
+    'use strict';
+    function getLimit (depth = 1) {
+        try {
+            return getLimit(depth + 1)
+        } catch (err) {
+            return depth
+        }
+    }
+    const limit = getLimit();
+    console.log(limit)
+
+    let err
+
+    function exhaust(depth, cb) {
+        try {
+            if (depth > 0) {
+                exhaust(depth - 1, cb)
+            } else {
+                cb('something')
+            }
+        } catch (_err) {
+            err =_err
+        }
+    }
+
+    
+    // exhausting the engine by calling a function from the sandbox
+    exhaust(limit - 1, function () {})
+
+    console.log('Sandboxed fn (throw?/sandboxed?): ', err !== undefined, err instanceof Error, err + '')
+
+    // exhausting the engine by calling a function from the sandbox
+    exhaust(limit - 1, console.log)
+    console.log('Outer fn (throw?/sandboxed?)', err !== undefined, err instanceof Error, err + '', err.stack + '')
+`);

--- a/examples/expandos.js
+++ b/examples/expandos.js
@@ -1,11 +1,7 @@
 import createSecureEnvironment from '../lib/browser-realm.js';
 
-const secureGlobalThis = createSecureEnvironment();
-const elm = secureGlobalThis.document.createElement('p');
-secureGlobalThis.document.body.appendChild(elm);
-console.log(document.body.outerHTML);
-console.log(secureGlobalThis.document.body.outerHTML);
-secureGlobalThis.eval(`
+const evalScript = createSecureEnvironment();
+evalScript(`
     debugger;
 
     const elm = document.createElement('p');
@@ -16,6 +12,8 @@ secureGlobalThis.eval(`
     // expandos are available inside the secure env
     console.log(document.querySelector('p').foo); // -> 1
 `);
+
+console.log(document.body.outerHTML);
 
 // expandos are not available in the outer realm
 console.log(document.querySelector('p').foo); // -> undefined

--- a/examples/getter-distortion.js
+++ b/examples/getter-distortion.js
@@ -10,9 +10,9 @@ const distortionMap = new Map([
     }],
 ]);
 
-const secureGlobalThis = createSecureEnvironment(distortionMap);
+const evalScript = createSecureEnvironment(distortionMap);
 
-secureGlobalThis.eval(`
+evalScript(`
     debugger;
 
     // the distortion of ShadowRoot.prototype.host returns null

--- a/examples/invalid-fetch.js
+++ b/examples/invalid-fetch.js
@@ -9,23 +9,23 @@ const distortionMap = new Map([
         console.error('forbidden');
     }],
 ]);
-const secureGlobalThis = createSecureEnvironment(distortionMap);
+const evalScript = createSecureEnvironment(distortionMap);
 
-secureGlobalThis.eval(`
+evalScript(`
     debugger;
 
     // the distortion of fetch does nothing
     window.fetch('./invalid-network-request.json');
 `);
 
-secureGlobalThis.eval(`
+evalScript(`
     debugger;
 
     // it will also throw because distortion it is based on identity
     window.originalFetch('./invalid-fetch.html');
 `);
 
-secureGlobalThis.eval(`
+evalScript(`
     debugger;
 
     // it will bypass the restriction because fetch ref never goes throw the membrane

--- a/examples/object-graph-mutations.js
+++ b/examples/object-graph-mutations.js
@@ -1,37 +1,6 @@
 import createSecureEnvironment from '../lib/browser-realm.js';
 
-globalThis.expect = (msg) => { 
-    return {
-        toBe(value) {
-            console.log(msg, value);
-        }
-    }
-};
-
-globalThis.baz = { a:1, b: 2 };
-
 const evalScript = createSecureEnvironment();
-
-// checking the state of bar in the sandbox
-evalScript(`    
-    expect(Object.isExtensible(globalThis.bar)).toBe(true);
-    expect(Object.isSealed(globalThis.bar)).toBe(false);
-    expect(Object.isFrozen(globalThis.bar)).toBe(false);
-`);
-// freezing the raw value after being observed by the sandbox
-Object.freeze(globalThis.baz);
-expect(Object.isExtensible(globalThis.baz)).toBe(false);
-expect(Object.isSealed(globalThis.baz)).toBe(true);
-expect(Object.isFrozen(globalThis.baz)).toBe(true);
-// verifying the state of the obj from within the sandbox
-evalScript(`
-    'use strict';
-    debugger;
-    baz.c = 3;
-    expect(baz.c).toBe(3);
-`);
-expect(globalThis.baz.c).toBe(undefined); // because it is a sandboxed expando that doesn't leak out
-
 
 evalScript(`
     'use strict';

--- a/examples/object-graph-mutations.js
+++ b/examples/object-graph-mutations.js
@@ -1,8 +1,40 @@
 import createSecureEnvironment from '../lib/browser-realm.js';
 
-const secureGlobalThis = createSecureEnvironment();
+globalThis.expect = (msg) => { 
+    return {
+        toBe(value) {
+            console.log(msg, value);
+        }
+    }
+};
 
-secureGlobalThis.eval(`
+globalThis.baz = { a:1, b: 2 };
+
+const evalScript = createSecureEnvironment();
+
+// checking the state of bar in the sandbox
+evalScript(`    
+    expect(Object.isExtensible(globalThis.bar)).toBe(true);
+    expect(Object.isSealed(globalThis.bar)).toBe(false);
+    expect(Object.isFrozen(globalThis.bar)).toBe(false);
+`);
+// freezing the raw value after being observed by the sandbox
+Object.freeze(globalThis.baz);
+expect(Object.isExtensible(globalThis.baz)).toBe(false);
+expect(Object.isSealed(globalThis.baz)).toBe(true);
+expect(Object.isFrozen(globalThis.baz)).toBe(true);
+// verifying the state of the obj from within the sandbox
+evalScript(`
+    'use strict';
+    debugger;
+    baz.c = 3;
+    expect(baz.c).toBe(3);
+`);
+expect(globalThis.baz.c).toBe(undefined); // because it is a sandboxed expando that doesn't leak out
+
+
+evalScript(`
+    'use strict';
     debugger;
 
     const originalProto = HTMLParagraphElement.prototype.__proto__;

--- a/examples/web-components/platform.js
+++ b/examples/web-components/platform.js
@@ -9,14 +9,9 @@ distortionMap.set(ShadowRootHostGetter, _ => { throw new Error(`Forbidden`); });
 distortionMap.set(assignedNodes, _ => { throw new Error(`Forbidden`); });
 distortionMap.set(assignedElements, _ => { throw new Error(`Forbidden`); });
 
-function distortionCallback(t) {
-    const d = distortionMap.get(t);
-    return d === undefined ? t : d;
-}
-
 function evaluateInNewSandbox(sourceText) {
-    const secureGlobalThis = createSecureEnvironment(distortionCallback);
-    secureGlobalThis.eval(sourceText);
+    const evalScript = createSecureEnvironment(distortionMap);
+    evalScript(sourceText);
 }
 
 document.querySelector('button').addEventListener('click', function (e) {

--- a/src/__tests__/error.spec.ts
+++ b/src/__tests__/error.spec.ts
@@ -85,4 +85,13 @@ describe('The Error Boundary', () => {
             `);
         }).toThrowError(TypeError);
     });
+    it('should protect from leaking sandbox errors during parsing', function() {
+        const evalScript = createSecureEnvironment();
+
+        expect(() => {
+            evalScript(`
+                return; // illegal return statement
+            `);
+        }).toThrowError(SyntaxError);
+    });
 });

--- a/src/__tests__/error.spec.ts
+++ b/src/__tests__/error.spec.ts
@@ -23,59 +23,45 @@ globalThis.foo = {
 
 describe('The Error Boundary', () => {
     it('should preserve identity of errors after a membrane roundtrip', function() {
-        const secureGlobalThis = createSecureEnvironment((v) => v);
-        secureGlobalThis.eval(`foo.expose(() => { foo.a })`);
+        expect.assertions(3);
+        const evalScript = createSecureEnvironment();
+        evalScript(`foo.expose(() => { foo.a })`);
         expect(() => {
             sandboxedValue();
         }).toThrowError(Error);
-        secureGlobalThis.eval(`foo.expose(() => { foo.a = 1; })`);
+        evalScript(`foo.expose(() => { foo.a = 1; })`);
         expect(() => {
             sandboxedValue();
         }).toThrowError(Error);
-        secureGlobalThis.eval(`foo.expose(() => { foo.b(2); })`);
+        evalScript(`foo.expose(() => { foo.b(2); })`);
         expect(() => {
             sandboxedValue();
         }).toThrowError(RangeError);
     });
     it('should remap the Outer Realm Error instance to the sandbox errors', function() {
-        const secureGlobalThis = createSecureEnvironment((v) => v);
-        expect(() => {
-            secureGlobalThis.eval(`
-                try {
-                    foo.a;
-                } catch (e) {
-                    if (!(e instanceof Error)) {
-                        throw new Error('Invalid Error Identity');
-                    }
-                }
-            `);
-        }).not.toThrowError();
-        expect(() => {
-            secureGlobalThis.eval(`
-                try {
-                    foo.a = 1;
-                } catch (e) {
-                    if (!(e instanceof Error)) {
-                        throw new Error('Invalid Error Identity');
-                    }
-                }
-            `);
-        }).not.toThrowError();
-        expect(() => {
-            secureGlobalThis.eval(`
-                try {
-                    foo.b(2);
-                } catch (e) {
-                    if (!(e instanceof RangeError)) {
-                        throw new Error('Invalid Error Identity');
-                    }
-                }
-            `);
-        }).not.toThrowError();
+        expect.assertions(3);
+        const evalScript = createSecureEnvironment();
+
+        evalScript(`
+            expect(() => {
+                foo.a;
+            }).toThrowError(Error);
+        `);
+        evalScript(`
+            expect(() => {
+                foo.a = 1;
+            }).toThrowError(Error);
+        `);
+        evalScript(`
+            expect(() => {
+                foo.b(2);
+            }).toThrowError(RangeError);
+        `);
     });
     it('should capture throwing from user proxy', function() {
-        const secureGlobalThis = createSecureEnvironment((v) => v);
-        secureGlobalThis.eval(`
+        expect.assertions(3);
+        const evalScript = createSecureEnvironment();
+        evalScript(`
             const revocable = Proxy.revocable(() => undefined, {});
             revocable.revoke();
             foo.expose(revocable.proxy);
@@ -89,5 +75,14 @@ describe('The Error Boundary', () => {
         expect(() => {
             delete sandboxedValue.x;
         }).toThrowError(Error);
+    });
+    it('should protect from leaking sandbox errors during evaluation', function() {
+        const evalScript = createSecureEnvironment();
+        
+        expect(() => {
+            evalScript(`
+                throw new TypeError('from sandbox');
+            `);
+        }).toThrowError(TypeError);
     });
 });

--- a/src/__tests__/freezing.spec.ts
+++ b/src/__tests__/freezing.spec.ts
@@ -3,7 +3,7 @@ import createSecureEnvironment from '../node-realm';
 describe('Freezing', () => {
     describe('before creating the sandbox', () => {
         it('should be observed from within the sandbox', function() {
-            expect.assertions(8);
+            expect.assertions(10);
             globalThis.bar = { a: 1, b: 2 };
             Object.freeze(globalThis.bar)
             const evalScript = createSecureEnvironment();
@@ -20,8 +20,26 @@ describe('Freezing', () => {
             // verifying that in deep it is reflected as frozen
             evalScript(`
                 'use strict';
-                expect(() => {
+                let isTypeError = false;
+                try {
                     bar.c = 3; // because it is frozen
+                } catch (e) {
+                    isTypeError = e instanceof TypeError;
+                }
+                expect(isTypeError).toBe(true);
+                expect(bar.c).toBe(undefined);
+            `);
+            // verifying that when observed from outside, it is still reflected
+            evalScript(`
+                'use strict';
+                let error = null;
+                try {
+                    bar.c = 3; // because it is frozen
+                } catch (e) {
+                    error = e;
+                }
+                expect(() => {
+                    bar.c = 3;
                 }).toThrow(TypeError);
                 expect(bar.c).toBe(undefined);
             `);

--- a/src/__tests__/freezing.spec.ts
+++ b/src/__tests__/freezing.spec.ts
@@ -4,7 +4,7 @@ describe('Freezing', () => {
     describe('before creating the sandbox', () => {
         it('should be observed from within the sandbox', function() {
             expect.assertions(8);
-            globalThis.bar = { a:1, b: 2 };
+            globalThis.bar = { a: 1, b: 2 };
             Object.freeze(globalThis.bar)
             const evalScript = createSecureEnvironment();
             // checking the state of bar in the outer realm
@@ -22,7 +22,7 @@ describe('Freezing', () => {
                 'use strict';
                 expect(() => {
                     bar.c = 3; // because it is frozen
-                }).toThrow(Error);
+                }).toThrow(TypeError);
                 expect(bar.c).toBe(undefined);
             `);
         });

--- a/src/__tests__/freezing.spec.ts
+++ b/src/__tests__/freezing.spec.ts
@@ -3,39 +3,55 @@ import createSecureEnvironment from '../node-realm';
 describe('Freezing', () => {
     describe('before creating the sandbox', () => {
         it('should be observed from within the sandbox', function() {
+            expect.assertions(8);
             globalThis.bar = { a:1, b: 2 };
             Object.freeze(globalThis.bar)
-            const secureGlobalThis = createSecureEnvironment();
+            const evalScript = createSecureEnvironment();
+            // checking the state of bar in the outer realm
             expect(Object.isExtensible(globalThis.bar)).toBe(false);
             expect(Object.isSealed(globalThis.bar)).toBe(true);
             expect(Object.isFrozen(globalThis.bar)).toBe(true);
-            expect(secureGlobalThis.Object.isExtensible(secureGlobalThis.bar)).toBe(false);
-            expect(secureGlobalThis.Object.isSealed(secureGlobalThis.bar)).toBe(true);
-            expect(secureGlobalThis.Object.isFrozen(secureGlobalThis.bar)).toBe(true);
-            expect(() => {
-                secureGlobalThis.bar.c = 3;
-            }).toThrowError();
-            expect(secureGlobalThis.bar.c).toBe(undefined); // because it is frozen
+            // checking the state of bar in the sandbox
+            evalScript(`
+                expect(Object.isExtensible(globalThis.bar)).toBe(false);
+                expect(Object.isSealed(globalThis.bar)).toBe(true);
+                expect(Object.isFrozen(globalThis.bar)).toBe(true);
+            `);
+            // verifying that in deep it is reflected as frozen
+            evalScript(`
+                'use strict';
+                expect(() => {
+                    bar.c = 3; // because it is frozen
+                }).toThrow(Error);
+                expect(bar.c).toBe(undefined);
+            `);
         });
     });
     describe('after creating the sandbox', () => {
         it('should not be observed from within the sandbox', function() {
+            expect.assertions(9);
             globalThis.baz = { a:1, b: 2 };
-            const secureGlobalThis = createSecureEnvironment();
-            expect(secureGlobalThis.Object.isExtensible(secureGlobalThis.baz)).toBe(true);
-            expect(secureGlobalThis.Object.isSealed(secureGlobalThis.baz)).toBe(false);
-            expect(secureGlobalThis.Object.isFrozen(secureGlobalThis.baz)).toBe(false);
+            const evalScript = createSecureEnvironment();
+            // checking the state of bar in the sandbox
+            evalScript(`
+                expect(Object.isExtensible(globalThis.baz)).toBe(true);
+                expect(Object.isSealed(globalThis.baz)).toBe(false);
+                expect(Object.isFrozen(globalThis.baz)).toBe(false);
+            `);
             // freezing the raw value after being observed by the sandbox
             Object.freeze(globalThis.baz);
             expect(Object.isExtensible(globalThis.baz)).toBe(false);
             expect(Object.isSealed(globalThis.baz)).toBe(true);
             expect(Object.isFrozen(globalThis.baz)).toBe(true);
             // verifying the state of the obj from within the sandbox
-            secureGlobalThis.baz.c = 3;
-            expect(secureGlobalThis.Object.isExtensible(secureGlobalThis.baz)).toBe(true);
-            expect(secureGlobalThis.Object.isSealed(secureGlobalThis.baz)).toBe(false);
-            expect(secureGlobalThis.Object.isFrozen(secureGlobalThis.baz)).toBe(false);
-            expect(secureGlobalThis.baz.c).toBe(3); // because it wasn't frozen when the shadow target was constructed
+            evalScript(`
+                'use strict';
+                expect(() => {
+                    baz.c = 3;
+                }).not.toThrowError();
+                expect(baz.c).toBe(3);
+            `);
+            expect(globalThis.baz.c).toBe(undefined); // because it is a sandboxed expando that doesn't leak out
         });
     });
     describe('reverse proxies', () => {
@@ -49,8 +65,8 @@ describe('Freezing', () => {
                     o.z = 3;
                 }).toThrowError();
             }
-            const secureGlobalThis = createSecureEnvironment();
-            secureGlobalThis.eval(`outerObjectFactory({ x: 1, get y() { return 2 } }, function() {})`);
+            const evalScript = createSecureEnvironment();
+            evalScript(`outerObjectFactory({ x: 1, get y() { return 2 } }, function() {})`);
         });
     });
 });

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 import createSecureEnvironment from '../node-realm';
 
 describe('SecureEnvironment', () => {
-    describe('.constructor', () => {
+    describe('reverse proxies', () => {
         it('should not have identity discontinuity for arrays', function() {
             expect.assertions(6);
             (globalThis as any).outerArrayFactory = function (a1: any, a2: any) {
@@ -12,21 +12,55 @@ describe('SecureEnvironment', () => {
                 expect(a2 instanceof Array).toBe(true);
                 expect(a2).toStrictEqual([3, 4]);
             }
-            const secureGlobalThis = createSecureEnvironment();
-            secureGlobalThis.eval(`outerArrayFactory([1, 2], new Array(3, 4))`);
+            const evalScript = createSecureEnvironment();
+            evalScript(`outerArrayFactory([1, 2], new Array(3, 4))`);
         });
         it('should not have identity discontinuity for objects', function() {
             expect.assertions(6);
-            (globalThis as any).outerObjectFactory = function (a1: any, a2: any) {
-                expect(typeof a1 === 'object').toBe(true);
-                expect(a1 instanceof Object).toBe(true);
-                expect(a1.x).toBe(1);
-                expect(typeof a2 === 'object').toBe(true);
-                expect(a2 instanceof Object).toBe(true);
-                expect(a2.x).toBe(2);
+            (globalThis as any).outerObjectFactory = function (b1: any, b2: any) {
+                expect(typeof b1 === 'object').toBe(true);
+                expect(b1 instanceof Object).toBe(true);
+                expect(b1.x).toBe(1);
+                expect(typeof b2 === 'object').toBe(true);
+                expect(b2 instanceof Object).toBe(true);
+                expect(b2.x).toBe(2);
             }
-            const secureGlobalThis = createSecureEnvironment();
-            secureGlobalThis.eval(`outerObjectFactory({ x: 1 }, { x: 2 })`);
+            const evalScript = createSecureEnvironment();
+            evalScript(`outerObjectFactory({ x: 1 }, Object.create({}, { x: { value: 2 } }))`);
+        });
+    });
+    describe('secure proxies', () => {
+        globalThis.foo = {
+            a1: [1, 2],
+            a2: new Array(3, 4),
+            b1: { x: 1 },
+            b2: Object.create({}, { x: { value: 2 } }),
+        };
+        it('should not have identity discontinuity for arrays', function() {
+            expect.assertions(6);
+            const evalScript = createSecureEnvironment();
+            evalScript(`
+                const { a1, a2 } = foo;
+                expect(Array.isArray(a1)).toBe(true);
+                expect(a1 instanceof Array).toBe(true);
+                expect(a1).toStrictEqual([1, 2]);
+                expect(Array.isArray(a2)).toBe(true);
+                expect(a2 instanceof Array).toBe(true);
+                expect(a2).toStrictEqual([3, 4]);
+            `);
+        });
+        it('should not have identity discontinuity for objects', function() {
+            expect.assertions(6);
+            const evalScript = createSecureEnvironment();
+            evalScript(`
+                const { b1, b2 } = foo;
+                expect(typeof b1 === 'object').toBe(true);
+                expect(b1 instanceof Object).toBe(true);
+                expect(b1.x).toBe(1);
+                expect(typeof b2 === 'object').toBe(true);
+                expect(b2 instanceof Object).toBe(true);
+                expect(b2.x).toBe(2);
+            `);
         });
     });
 });

--- a/src/__tests__/reflection.spec.ts
+++ b/src/__tests__/reflection.spec.ts
@@ -7,45 +7,30 @@ globalThis.foo = {
 
 describe('Reflective Intrinsic Objects', () => {
     it('should preserve identity of Object thru membrane', function() {
-        const secureGlobalThis = createSecureEnvironment((v) => v);
-        expect(() => {
-            secureGlobalThis.eval(`
-                if (!(foo instanceof Object)) {
-                    throw new Error('Invalid Identity of foo');
-                }
-                const o = {};
-                if (!(o instanceof Object)) {
-                    throw new Error('Invalid Identity of o');
-                }
-            `);
-        }).not.toThrowError();
+        expect.assertions(2);
+        const evalScript = createSecureEnvironment();
+        evalScript(`
+            const o = {};
+            expect(foo instanceof Object).toBe(true);
+            expect(o instanceof Object).toBe(true);
+        `);
     });
     it('should preserve identity of Function thru membrane', function() {
-        const secureGlobalThis = createSecureEnvironment((v) => v);
-        expect(() => {
-            secureGlobalThis.eval(`
-                if (!(foo.b instanceof Function)) {
-                    throw new Error('Invalid Identity of foo.b');
-                }
-                function x() {}
-                if (!(x instanceof Function)) {
-                    throw new Error('Invalid Identity of x');
-                }
-            `);
-        }).not.toThrowError();
+        expect.assertions(2);
+        const evalScript = createSecureEnvironment();
+        evalScript(`
+            function x() {}
+            expect(foo.b instanceof Function).toBe(true);
+            expect(x instanceof Function).toBe(true);
+        `);
     });
     it('should preserve identity of Error thru membrane', function() {
-        const secureGlobalThis = createSecureEnvironment((v) => v);
-        expect(() => {
-            secureGlobalThis.eval(`
-                if (!(foo.e instanceof Error)) {
-                    throw new Error('Invalid Identity of foo.e');
-                }
-                const e = new Error();
-                if (!(e instanceof Error)) {
-                    throw new Error('Invalid Identity of e');
-                }
-            `);
-        }).not.toThrowError();
+        expect.assertions(2);
+        const evalScript = createSecureEnvironment();
+        evalScript(`
+            const e = new Error();
+            expect(foo.e instanceof Error).toBe(true);
+            expect(e instanceof Error).toBe(true);
+        `);
     });
 });

--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -32,7 +32,7 @@ export default function createSecureEnvironment(distortionMap?: Map<SecureProxyT
     // In Chrome debugger statements will be ignored when the iframe is removed
     // from the document. Other browsers like Firefox and Safari work as expected.
     // https://bugs.chromium.org/p/chromium/issues/detail?id=1015462
-    // iframe.remove();
+    iframe.remove();
 
     // window -> Window -> WindowProperties -> EventTarget
     const secureDocument = secureWindow.document;

--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -5,6 +5,7 @@ import {
     ReflectSetPrototypeOf, 
     getOwnPropertyDescriptors,
     construct,
+    ErrorCreate,
 } from "./shared";
 
 // caching references to object values that can't be replaced
@@ -74,25 +75,15 @@ export default function createSecureEnvironment(distortionMap?: Map<SecureProxyT
             secureIndirectEval(sourceText);
         } catch (e) {
             // This error occurred when the outer realm attempts to evaluate a
-            // sourceText into the sandbox.
-            try {
-                throw e;
-            } catch (e) {
-                // for some errors, re-throwing them is sufficient to correct
-                // the identity of the error, in which case we just use that.
-                if (e instanceof Error) {
-                    throw e;
-                }
-            }
-            // otherwise throwing a new raw error, which eliminates the stack
-            // information from the sandbox as a consequence.
+            // sourceText into the sandbox. By throwing a new raw error, which
+            // eliminates the stack information from the sandbox as a consequence.
             let rawError;
-            const { message } = e as any;
+            const { message, constructor } = e;
             try {
-                rawError = construct(env.getRawValue(e.constructor), [message]);
+                rawError = construct(env.getRawRef(constructor), [message]);
             } catch (ignored) {
                 // in case the constructor inference fails
-                rawError = construct(Error, [message]);
+                rawError = ErrorCreate(message);
             }
             throw rawError;
         }

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -311,4 +311,18 @@ export class SecureEnvironment {
         // identity of the new array correspond to the outer realm
         return map(a, (sec: SecureValue) => this.getRawValue(sec));
     }
+    getRawError(e: Error | object): Error {
+        if (e instanceof Error) {
+            return e;
+        }
+        let rawError;
+        const { message } = e as any;
+        try {
+            rawError = construct(this.getRawValue(e.constructor), [message]);
+        } catch (ignored) {
+            // in case the constructor inference fails
+            rawError = construct(Error, [message]);
+        }
+        return rawError;
+    }
 }

--- a/src/membrane.ts
+++ b/src/membrane.ts
@@ -37,6 +37,9 @@ export interface TargetMeta {
     isBroken?: true;
 }
 
+export type SecureProxy = SecureObject | SecureFunction;
+export type ReverseProxy = RawObject | RawFunction;
+
 export function getTargetMeta(target: SecureProxyTarget | ReverseProxyTarget): TargetMeta {
     const meta: TargetMeta = ObjectCreate(null);
     try {

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -1,6 +1,6 @@
 import { SecureEnvironment } from "./environment";
 import { SecureProxyTarget } from "./membrane";
-import { getOwnPropertyDescriptors } from "./shared";
+import { getOwnPropertyDescriptors, construct } from "./shared";
 import { createContext, runInContext } from 'vm';
 
 // note: in a node module, the top-level 'this' is not the global object
@@ -12,6 +12,7 @@ export default function createSecureEnvironment(distortionMap?: Map<SecureProxyT
     // Use unsafeGlobalEvalSrc to ensure we get the right 'this'.
     const context = createContext();
     const secureGlobalThis = runInContext(unsafeGlobalEvalSrc, context);
+    const { eval: secureIndirectEval } = secureGlobalThis;
     const rawGlobalThis = globalThis as any;
     const rawGlobalThisDescriptors = getOwnPropertyDescriptors(rawGlobalThis);
     const env = new SecureEnvironment({
@@ -25,12 +26,30 @@ export default function createSecureEnvironment(distortionMap?: Map<SecureProxyT
 
     return (sourceText: string): void => {
         try {
-            runInContext(sourceText, context);
+            secureIndirectEval(sourceText);
         } catch (e) {
             // This error occurred when the outer realm attempts to evaluate a
             // sourceText into the sandbox.
-            // - By throwing a new raw error, we eliminate the stack information from the sandbox
-            throw env.getRawError(e);
+            try {
+                throw e;
+            } catch (e) {
+                // for some errors, re-throwing them is sufficient to correct
+                // the identity of the error, in which case we just use that.
+                if (e instanceof Error) {
+                    throw e;
+                }
+            }
+            // otherwise throwing a new raw error, which eliminates the stack
+            // information from the sandbox as a consequence.
+            let rawError;
+            const { message } = e as any;
+            try {
+                rawError = construct(env.getRawValue(e.constructor), [message]);
+            } catch (ignored) {
+                // in case the constructor inference fails
+                rawError = construct(Error, [message]);
+            }
+            throw rawError;
         }
     };
 }

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -1,16 +1,17 @@
 import { SecureEnvironment } from "./environment";
 import { SecureProxyTarget } from "./membrane";
 import { getOwnPropertyDescriptors } from "./shared";
-import { runInNewContext } from 'vm';
+import { createContext, runInContext } from 'vm';
 
 // note: in a node module, the top-level 'this' is not the global object
 // (it's *something* but we aren't sure what), however an indirect eval of
 // 'this' will be the correct global object.
 const unsafeGlobalEvalSrc = `(0, eval)("'use strict'; this")`;
 
-export default function createSecureEnvironment(distortionMap?: Map<SecureProxyTarget, SecureProxyTarget>): typeof globalThis {
+export default function createSecureEnvironment(distortionMap?: Map<SecureProxyTarget, SecureProxyTarget>): (sourceText: string) => void {
     // Use unsafeGlobalEvalSrc to ensure we get the right 'this'.
-    const secureGlobalThis = runInNewContext(unsafeGlobalEvalSrc);
+    const context = createContext();
+    const secureGlobalThis = runInContext(unsafeGlobalEvalSrc, context);
     const rawGlobalThis = globalThis as any;
     const rawGlobalThisDescriptors = getOwnPropertyDescriptors(rawGlobalThis);
     const env = new SecureEnvironment({
@@ -22,5 +23,14 @@ export default function createSecureEnvironment(distortionMap?: Map<SecureProxyT
     // remapping globals
     env.remap(secureGlobalThis, rawGlobalThis, rawGlobalThisDescriptors);
 
-    return secureGlobalThis;
+    return (sourceText: string): void => {
+        try {
+            runInContext(sourceText, context);
+        } catch (e) {
+            // This error occurred when the outer realm attempts to evaluate a
+            // sourceText into the sandbox.
+            // - By throwing a new raw error, we eliminate the stack information from the sandbox
+            throw env.getRawError(e);
+        }
+    };
 }

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -1,7 +1,7 @@
 import { SecureEnvironment } from "./environment";
 import { SecureProxyTarget } from "./membrane";
 import { getOwnPropertyDescriptors, construct, ErrorCreate } from "./shared";
-import { createContext, runInContext } from 'vm';
+import { runInNewContext } from 'vm';
 
 // note: in a node module, the top-level 'this' is not the global object
 // (it's *something* but we aren't sure what), however an indirect eval of
@@ -10,8 +10,7 @@ const unsafeGlobalEvalSrc = `(0, eval)("'use strict'; this")`;
 
 export default function createSecureEnvironment(distortionMap?: Map<SecureProxyTarget, SecureProxyTarget>): (sourceText: string) => void {
     // Use unsafeGlobalEvalSrc to ensure we get the right 'this'.
-    const context = createContext();
-    const secureGlobalThis = runInContext(unsafeGlobalEvalSrc, context);
+    const secureGlobalThis = runInNewContext(unsafeGlobalEvalSrc);
     const { eval: secureIndirectEval } = secureGlobalThis;
     const rawGlobalThis = globalThis as any;
     const rawGlobalThisDescriptors = getOwnPropertyDescriptors(rawGlobalThis);

--- a/src/reverse-proxy-handler.ts
+++ b/src/reverse-proxy-handler.ts
@@ -31,7 +31,7 @@ function getReverseDescriptor(descriptor: PropertyDescriptor, env: SecureEnviron
             env.getRawFunction(value) : env.getRawValue(value);
     } else {
         // we are dealing with accessors
-        if (isFunction(set)) { 
+        if (isFunction(set)) {
             reverseDescriptor.set = env.getRawFunction(set);
         }
         if (isFunction(get)) {
@@ -56,19 +56,8 @@ function callWithErrorBoundaryProtection(env: SecureEnvironment, fn: () => RawVa
     try {
         raw = fn();
     } catch (e) {
-        // This error occurred when the outer realm invokes a function from the sandbox.
-        if (e instanceof Error) {
-            throw e;
-        }
-        let rawError;
-        try {
-            rawError = construct(env.getRawValue(e.constructor), [e.message]);
-        } catch (ignored) {
-            // in case the constructor inference fails
-            rawError = construct(Error, [e.message]);
-        }
         // by throwing a new raw error, we eliminate the stack information from the sandbox
-        throw rawError;
+        throw env.getRawError(e);
     }
     return raw;
 }

--- a/src/secure-proxy-handler.ts
+++ b/src/secure-proxy-handler.ts
@@ -1,23 +1,14 @@
-import {
-    apply,
-    assign,
-    construct,
-    deleteProperty,
-    isUndefined,
-    ObjectCreate,
-    ObjectDefineProperty,
-    ReflectSetPrototypeOf,
-    ReflectGetPrototypeOf,
-    ReflectIsExtensible,
-    ReflectGetOwnPropertyDescriptor,
-    ownKeys,
-    ReflectPreventExtensions,
-    isFunction,
-    freeze,
-    emptyArray,
-    hasOwnProperty,
-    seal,
-} from './shared';
+/**
+ * This file implements a serializable factory function that is invoked once per sandbox
+ * and it is used to create secure proxy handlers where all identities are defined inside
+ * the sandbox, this guarantees that any error when interacting with those proxies, has
+ * the proper identity to avoid leaking references from the outer realm into the sandbox
+ * this is especially important for out of memory errors.
+ *
+ * IMPORTANT:
+ *  - This file can't import anything from the package, only types since it is going to
+ *    be serialized, and therefore it will loose the reference.
+ */
 import {
     SecureEnvironment,
 } from './environment';
@@ -25,233 +16,245 @@ import {
     SecureProxyTarget,
     SecureValue,
     SecureObject,
+    SecureShadowTarget,
     RawConstructor,
     RawFunction,
-    SecureShadowTarget,
 } from './membrane';
-import { TargetMeta, installDescriptorIntoShadowTarget } from './membrane';
+import { TargetMeta } from './membrane';
 
-export function getSecureDescriptor(descriptor: PropertyDescriptor, env: SecureEnvironment): PropertyDescriptor {
-    const secureDescriptor = assign(ObjectCreate(null), descriptor);
-    const { value, get, set } = secureDescriptor;
-    if ('writable' in secureDescriptor) {
-        // we are dealing with a value descriptor
-        secureDescriptor.value = isFunction(value) ?
-            // we are dealing with a method (optimization)
-            env.getSecureFunction(value) : env.getSecureValue(value);
-    } else {
-        // we are dealing with accessors
-        if (isFunction(set)) {
-            secureDescriptor.set = env.getSecureFunction(set);
-        }
-        if (isFunction(get)) {
-            secureDescriptor.get = env.getSecureFunction(get);
-        }
-    }
-    return secureDescriptor;
-}
+export const serializedSecureProxyHandlerFactory = (function secureProxyHandlerFactory(env: SecureEnvironment) {
+    'use strict';
 
-// equivalent to Object.getOwnPropertyDescriptor, but looks into the whole proto chain
-function getPropertyDescriptor(o: any, p: PropertyKey): PropertyDescriptor | undefined {
-    do {
-        const d = ReflectGetOwnPropertyDescriptor(o, p);
-        if (!isUndefined(d)) {
-            ReflectSetPrototypeOf(d, null);
-            return d;
-        }
-        o = ReflectGetPrototypeOf(o);
-    } while (o !== null);
-    return undefined;
-}
+    const {
+        apply,
+        construct,
+        isExtensible,
+        getOwnPropertyDescriptor,
+        setPrototypeOf,
+        getPrototypeOf,
+        preventExtensions,
+        deleteProperty,
+        ownKeys,
+        defineProperty,
+    } = Reflect;
+    const { seal, freeze, defineProperty: ObjectDefineProperty, create, assign, hasOwnProperty } = Object;
+    const emptyArray: [] = [];
 
-function copySecureOwnDescriptors(env: SecureEnvironment, shadowTarget: SecureShadowTarget, descriptors: PropertyDescriptorMap) {
-    for (const key in descriptors) {
-        // avoid poisoning by checking own properties from descriptors
-        if (hasOwnProperty(descriptors, key)) {
-            const originalDescriptor = getSecureDescriptor(descriptors[key], env);
-            installDescriptorIntoShadowTarget(shadowTarget, key, originalDescriptor);
-        }
-    }
-}
-
-function callWithErrorBoundaryProtection(env: SecureEnvironment, fn: () => SecureValue): SecureValue {
-    let sec;
-    try {
-        sec = fn();
-    } catch (e) {
-        // This error occurred when a sandbox invokes a function from the outer realm.
-        if (e instanceof Error) {
-            let secError;
-            try {
-                secError = construct(env.getSecureValue(e.constructor), [e.message]);
-            } catch (ignored) {
-                // in case the constructor inference fails
-                secError = construct(env.getSecureValue(Error), [e.message]);
-            }
-            // by throwing a new secure error, we eliminate the stack information from the outer realm
-            throw secError;
-        }
-        throw e;
-    }
-    return sec;
-}
-
-const noop = () => undefined;
-
-/**
- * identity preserved through this membrane:
- *  - symbols
- */
-export class SecureProxyHandler implements ProxyHandler<SecureProxyTarget> {
-    // original target for the proxy
-    private readonly target: SecureProxyTarget;
-    // environment object that controls the realm
-    private readonly env: SecureEnvironment;
-    // metadata about the shape of the target
-    private readonly meta: TargetMeta;
-
-    constructor(env: SecureEnvironment, target: SecureProxyTarget, meta: TargetMeta) {
-        this.target = target;
-        this.meta = meta;
-        this.env = env;
-    }
-    // initialization used to avoid the initialization cost
-    // of an object graph, we want to do it when the
-    // first interaction happens.
-    private initialize(shadowTarget: SecureShadowTarget) {
-        const { meta, env } = this;
-        // once the initialization is executed once... the rest is just noop 
-        this.initialize = noop;
-        // adjusting the proto chain of the shadowTarget (recursively)
-        const secProto = env.getSecureValue(meta.proto);
-        ReflectSetPrototypeOf(shadowTarget, secProto);
-        // defining own descriptors
-        copySecureOwnDescriptors(env, shadowTarget, meta.descriptors);
-        // preserving the semantics of the object
-        if (meta.isFrozen) {
-            freeze(shadowTarget);
-        } else if (meta.isSealed) {
-            seal(shadowTarget);
-        } else if (!meta.isExtensible) {
-            ReflectPreventExtensions(shadowTarget);
-        }
-        // future optimization: hoping that proxies with frozen handlers can be faster
-        freeze(this);
+    function isUndefined(obj: any): obj is undefined {
+        return obj === undefined;
     }
 
-    get(shadowTarget: SecureShadowTarget, key: PropertyKey, receiver: SecureObject): SecureValue {
-        this.initialize(shadowTarget);
-        const desc = getPropertyDescriptor(shadowTarget, key);
-        if (isUndefined(desc)) {
-            return desc;
-        }
-        const { get } = desc;
-        if (isFunction(get)) {
-            // calling the getter with the secure receiver because the getter expects a secure value
-            // it also returns a secure value
-            return apply(get, receiver, emptyArray);
-        }
-        return desc.value;
+    function isFunction(obj: any): obj is Function {
+        return typeof obj === 'function';
     }
-    set(shadowTarget: SecureShadowTarget, key: PropertyKey, value: SecureValue, receiver: SecureObject): boolean {
-        this.initialize(shadowTarget);
-        const shadowTargetDescriptor = getPropertyDescriptor(shadowTarget, key);
+
+    function installDescriptorIntoShadowTarget(shadowTarget: SecureProxyTarget, key: PropertyKey, originalDescriptor: PropertyDescriptor) {
+        const shadowTargetDescriptor = getOwnPropertyDescriptor(shadowTarget, key);
         if (!isUndefined(shadowTargetDescriptor)) {
-            // descriptor exists in the shadowTarget or proto chain
-            const { set, get, writable } = shadowTargetDescriptor;
-            if (writable === false) {
-                // TypeError: Cannot assign to read only property '${key}' of object
-                return false;
+            if (hasOwnProperty.call(shadowTargetDescriptor, 'configurable') &&
+                    shadowTargetDescriptor.configurable === true) {
+                defineProperty(shadowTarget, key, originalDescriptor);
+            } else if (hasOwnProperty.call(shadowTargetDescriptor, 'writable') &&
+                    shadowTargetDescriptor.writable === true) {
+                // just in case
+                shadowTarget[key] = originalDescriptor.value;
+            } else {
+                // ignoring... since it is non configurable and non-writable
+                // usually, arguments, callee, etc.
             }
+        } else {
+            defineProperty(shadowTarget, key, originalDescriptor);
+        }
+    }
+
+    function getSecureDescriptor(descriptor: PropertyDescriptor): PropertyDescriptor {
+        const secureDescriptor = assign(create(null), descriptor);
+        const { value, get, set } = secureDescriptor;
+        if ('writable' in secureDescriptor) {
+            // we are dealing with a value descriptor
+            secureDescriptor.value = isFunction(value) ?
+                // we are dealing with a method (optimization)
+                env.getSecureFunction(value) : env.getSecureValue(value);
+        } else {
+            // we are dealing with accessors
             if (isFunction(set)) {
-                // a setter is available, just call it with the secure value because
-                // the setter expects a secure value
-                apply(set, receiver, [value]);
-                return true;
+                secureDescriptor.set = env.getSecureFunction(set);
             }
             if (isFunction(get)) {
-                // a getter without a setter should fail to set in strict mode
-                // TypeError: Cannot set property ${key} of object which has only a getter
-                return false;
+                secureDescriptor.get = env.getSecureFunction(get);
             }
-        } else if (!ReflectIsExtensible(shadowTarget)) {
-            // non-extensible should throw in strict mode
-            // TypeError: Cannot add property ${key}, object is not extensible
-            return false;
         }
-        // the descriptor is writable on the obj or proto chain, just assign it
-        shadowTarget[key] = value;
-        return true;
+        return secureDescriptor;
     }
-    deleteProperty(shadowTarget: SecureShadowTarget, key: PropertyKey): boolean {
-        this.initialize(shadowTarget);
-        return deleteProperty(shadowTarget, key);
-    }
-    apply(shadowTarget: SecureShadowTarget, thisArg: SecureValue, argArray: SecureValue[]): SecureValue {
-        const { target, env } = this;
-        this.initialize(shadowTarget);
-        const rawThisArg = env.getRawValue(thisArg);
-        const rawArgArray = env.getRawArray(argArray);
-        return callWithErrorBoundaryProtection(env, () => {
-            const raw = apply(target as RawFunction, rawThisArg, rawArgArray);
-            return env.getSecureValue(raw);
-        });
-    }
-    construct(shadowTarget: SecureShadowTarget, argArray: SecureValue[], newTarget: SecureObject): SecureObject {
-        const { target: RawCtor, env } = this;
-        this.initialize(shadowTarget);
-        if (newTarget === undefined) {
-            throw TypeError();
-        }
-        const rawArgArray = env.getRawArray(argArray);
-        const rawNewTarget = env.getRawValue(newTarget);
-        return callWithErrorBoundaryProtection(env, () => {
-            const raw = construct(RawCtor as RawConstructor, rawArgArray, rawNewTarget);
-            return env.getSecureValue(raw);
-        });
-    }
-    has(shadowTarget: SecureShadowTarget, key: PropertyKey): boolean {
-        this.initialize(shadowTarget);
-        return key in shadowTarget;
-    }
-    ownKeys(shadowTarget: SecureShadowTarget): PropertyKey[] {
-        this.initialize(shadowTarget);
-        return ownKeys(shadowTarget);
-    }
-    isExtensible(shadowTarget: SecureShadowTarget): boolean {
-        this.initialize(shadowTarget);
-        // No DOM API is non-extensible, but in the sandbox, the author
-        // might want to make them non-extensible
-        return ReflectIsExtensible(shadowTarget);
-    }
-    getOwnPropertyDescriptor(shadowTarget: SecureShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
-        this.initialize(shadowTarget);
-        // TODO: this is leaking outer realm's object
-        return ReflectGetOwnPropertyDescriptor(shadowTarget, key);
-    }
-    getPrototypeOf(shadowTarget: SecureShadowTarget): SecureValue {
-        this.initialize(shadowTarget);
-        // nothing to be done here since the shadowTarget must have the right proto chain
-        return ReflectGetPrototypeOf(shadowTarget);
-    }
-    setPrototypeOf(shadowTarget: SecureShadowTarget, prototype: SecureValue): boolean {
-        this.initialize(shadowTarget);
-        // this operation can only affect the env object graph
-        return ReflectSetPrototypeOf(shadowTarget, prototype);
-    }
-    preventExtensions(shadowTarget: SecureShadowTarget): boolean {
-        this.initialize(shadowTarget);
-        // this operation can only affect the env object graph
-        return ReflectPreventExtensions(shadowTarget);
-    }
-    defineProperty(shadowTarget: SecureShadowTarget, key: PropertyKey, descriptor: PropertyDescriptor): boolean {
-        this.initialize(shadowTarget);
-        // this operation can only affect the env object graph
-        // intentionally using Object.defineProperty instead of Reflect.defineProperty
-        // to throw for existing non-configurable descriptors.
-        ObjectDefineProperty(shadowTarget, key, descriptor);
-        return true;
-    }
-}
 
-ReflectSetPrototypeOf(SecureProxyHandler.prototype, null);
+    // equivalent to Object.getOwnPropertyDescriptor, but looks into the whole proto chain
+    function getPropertyDescriptor(o: any, p: PropertyKey): PropertyDescriptor | undefined {
+        do {
+            const d = getOwnPropertyDescriptor(o, p);
+            if (!isUndefined(d)) {
+                setPrototypeOf(d, null);
+                return d;
+            }
+            o = getPrototypeOf(o);
+        } while (o !== null);
+        return undefined;
+    }
+
+    function copySecureOwnDescriptors(shadowTarget: SecureShadowTarget, descriptors: PropertyDescriptorMap) {
+        for (const key in descriptors) {
+            // avoid poisoning by checking own properties from descriptors
+            if (hasOwnProperty.call(descriptors, key)) {
+                const originalDescriptor = getSecureDescriptor(descriptors[key]);
+                installDescriptorIntoShadowTarget(shadowTarget, key, originalDescriptor);
+            }
+        }
+    }
+
+    return function createSecureProxyHandler(target: SecureProxyTarget, meta: TargetMeta): ProxyHandler<SecureProxyTarget> {
+
+        // initialization used to avoid the initialization cost
+        // of an object graph, we want to do it when the
+        // first interaction happens.
+        let initialize = function (shadowTarget: SecureShadowTarget) {
+            // once the initialization is executed once... the rest is just noop
+            initialize = () => undefined;
+            // adjusting the proto chain of the shadowTarget (recursively)
+            const secProto = env.getSecureValue(meta.proto);
+            setPrototypeOf(shadowTarget, secProto);
+            // defining own descriptors
+            copySecureOwnDescriptors(shadowTarget, meta.descriptors);
+            // preserving the semantics of the object
+            if (meta.isFrozen) {
+                freeze(shadowTarget);
+            } else if (meta.isSealed) {
+                seal(shadowTarget);
+            } else if (!meta.isExtensible) {
+                preventExtensions(shadowTarget);
+            }
+        }
+
+        // future optimization: hoping that proxies with frozen handlers can be faster
+        return freeze({
+            get(shadowTarget: SecureShadowTarget, key: PropertyKey, receiver: SecureObject): SecureValue {
+                initialize(shadowTarget);
+                const desc = getPropertyDescriptor(shadowTarget, key);
+                if (isUndefined(desc)) {
+                    return desc;
+                }
+                const { get } = desc;
+                if (isFunction(get)) {
+                    // calling the getter with the secure receiver because the getter expects a secure value
+                    // it also returns a secure value
+                    return apply(get, receiver, emptyArray);
+                }
+                return desc.value;
+            },
+            set(shadowTarget: SecureShadowTarget, key: PropertyKey, value: SecureValue, receiver: SecureObject): boolean {
+                initialize(shadowTarget);
+                const shadowTargetDescriptor = getPropertyDescriptor(shadowTarget, key);
+                if (!isUndefined(shadowTargetDescriptor)) {
+                    // descriptor exists in the shadowTarget or proto chain
+                    const { set, get, writable } = shadowTargetDescriptor;
+                    if (writable === false) {
+                        // TypeError: Cannot assign to read only property '${key}' of object
+                        return false;
+                    }
+                    if (typeof set === 'function') {
+                        // a setter is available, just call it with the secure value because
+                        // the setter expects a secure value
+                        apply(set, receiver, [value]);
+                        return true;
+                    }
+                    if (typeof get === 'function') {
+                        // a getter without a setter should fail to set in strict mode
+                        // TypeError: Cannot set property ${key} of object which has only a getter
+                        return false;
+                    }
+                } else if (!isExtensible(shadowTarget)) {
+                    // non-extensible should throw in strict mode
+                    // TypeError: Cannot add property ${key}, object is not extensible
+                    return false;
+                }
+                // the descriptor is writable on the obj or proto chain, just assign it
+                shadowTarget[key] = value;
+                return true;
+            },
+            deleteProperty(shadowTarget: SecureShadowTarget, key: PropertyKey): boolean {
+                initialize(shadowTarget);
+                return deleteProperty(shadowTarget, key);
+            },
+            apply(shadowTarget: SecureShadowTarget, thisArg: SecureValue, argArray: SecureValue[]): SecureValue {
+                try {
+                    initialize(shadowTarget);
+                    const rawThisArg = env.getRawValue(thisArg);
+                    const rawArgArray = env.getRawArray(argArray);
+                    const raw = apply(target as RawFunction, rawThisArg, rawArgArray);
+                    return env.getSecureValue(raw);
+                } catch (e) {
+                    // by throwing a new secure error, we prevent stack overflow errors
+                    // from outer realm to leak into the sandbox
+                    throw e;
+                }
+            },
+            construct(shadowTarget: SecureShadowTarget, argArray: SecureValue[], newTarget: SecureObject): SecureObject {
+                try {
+                    initialize(shadowTarget);
+                    if (isUndefined(newTarget)) {
+                        throw TypeError();
+                    }
+                    const rawArgArray = env.getRawArray(argArray);
+                    const rawNewTarget = env.getRawValue(newTarget);
+                    const raw = construct(target as RawConstructor, rawArgArray, rawNewTarget);
+                    return env.getSecureValue(raw);
+                } catch (e) {
+                    // by throwing a new secure error, we prevent stack overflow errors
+                    // from outer realm to leak into the sandbox
+                    throw e;
+                }
+            },
+            has(shadowTarget: SecureShadowTarget, key: PropertyKey): boolean {
+                initialize(shadowTarget);
+                return key in shadowTarget;
+            },
+            ownKeys(shadowTarget: SecureShadowTarget): PropertyKey[] {
+                initialize(shadowTarget);
+                return ownKeys(shadowTarget);
+            },
+            isExtensible(shadowTarget: SecureShadowTarget): boolean {
+                initialize(shadowTarget);
+                // No DOM API is non-extensible, but in the sandbox, the author
+                // might want to make them non-extensible
+                return isExtensible(shadowTarget);
+            },
+            getOwnPropertyDescriptor(shadowTarget: SecureShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
+                initialize(shadowTarget);
+                // TODO: this is leaking outer realm's object
+                return getOwnPropertyDescriptor(shadowTarget, key);
+            },
+            getPrototypeOf(shadowTarget: SecureShadowTarget): SecureValue {
+                initialize(shadowTarget);
+                // nothing to be done here since the shadowTarget must have the right proto chain
+                return getPrototypeOf(shadowTarget);
+            },
+            setPrototypeOf(shadowTarget: SecureShadowTarget, prototype: SecureValue): boolean {
+                initialize(shadowTarget);
+                // this operation can only affect the env object graph
+                return setPrototypeOf(shadowTarget, prototype);
+            },
+            preventExtensions(shadowTarget: SecureShadowTarget): boolean {
+                initialize(shadowTarget);
+                // this operation can only affect the env object graph
+                return preventExtensions(shadowTarget);
+            },
+            defineProperty(shadowTarget: SecureShadowTarget, key: PropertyKey, descriptor: PropertyDescriptor): boolean {
+                initialize(shadowTarget);
+                // this operation can only affect the env object graph
+                // intentionally using Object.defineProperty instead of Reflect.defineProperty
+                // to throw for existing non-configurable descriptors.
+                ObjectDefineProperty(shadowTarget, key, descriptor);
+                return true;
+            },
+        });
+
+    };
+}).toString();

--- a/src/secure-proxy-handler.ts
+++ b/src/secure-proxy-handler.ts
@@ -91,7 +91,7 @@ export const serializedSecureProxyFactory = (function secureProxyFactory(rawEnv:
 
     function getSecureDescriptor(rawDescriptor: PropertyDescriptor): PropertyDescriptor {
         const secureDescriptor = assign(create(null), rawDescriptor);
-        const { value: rawValue, get: rawGet, rawSet } = secureDescriptor;
+        const { value: rawValue, get: rawGet, set: rawSet } = secureDescriptor;
         if ('writable' in secureDescriptor) {
             // we are dealing with a value descriptor
             secureDescriptor.value = isFunction(rawValue) ?

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -193,3 +193,18 @@ export const ReflectiveIntrinsicObjectNames = [
     'EvalError',
     'Error',
 ];
+
+export function renameFunction(provider: (...args: any[]) => any, receiver: (...args: any[]) => any) {
+    let nameDescriptor: PropertyDescriptor | undefined;
+    try {
+        // a revoked proxy will break the membrane when reading the function name
+        nameDescriptor = ReflectGetOwnPropertyDescriptor(provider, 'name');
+    } catch (_ignored) {
+        // intentionally swallowing the error because this method is just extracting the function
+        // in a way that it should always succeed except for the cases in which the provider is a proxy
+        // that is either revoked or has some logic to prevent reading the name property descriptor.
+    }
+    if (!isUndefined(nameDescriptor)) {
+        ReflectDefineProperty(receiver, 'name', nameDescriptor);
+    }
+}


### PR DESCRIPTION
Changes:

* changed the public api of `environment.ts` to return a evaluator function per environment rather than the chaining of the secure global passed as argument.
* move evaluation of the proxy factory for secure objects into the sandbox via indirect eval.
* simplification of the environment.ts to be the record holder and be resilience to stack overflows.
* adjust all tests to rely on `expect` inside and outside the sandbox.
* protect against poisoning of the global eval

Related to https://github.com/caridy/secure-javascript-environment/issues/48