### PR TITLE
MapEntries util in SecureEnvironment

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -18,6 +18,7 @@ import {
     WeakMapSet,
     ReflectiveIntrinsicObjectNames,
     WeakMapGet,
+    MapEntries,
 } from './shared';
 import { serializedSecureEnvSourceText } from './secure-value';
 import { reverseProxyFactory } from './raw-value';
@@ -69,7 +70,7 @@ export class SecureEnvironment implements MembraneBroker {
             throw ErrorCreate(`Missing SecureEnvironmentOptions options bag.`);
         }
         const { rawGlobalThis, secureGlobalThis, distortionMap } = options;
-        this.distortionMap = WeakMapCreate(isUndefined(distortionMap) ? [] : distortionMap.entries());
+        this.distortionMap = WeakMapCreate(isUndefined(distortionMap) ? [] : MapEntries(distortionMap));
         // getting proxy factories ready per environment so we can produce
         // the proper errors without leaking instances into a sandbox
         const secureEnvFactory = secureGlobalThis.eval(`(${serializedSecureEnvSourceText})`);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -34,6 +34,8 @@ const WeakMapSet = unapply(WeakMap.prototype.set);
 const hasOwnProperty = unapply(Object.prototype.hasOwnProperty);
 const map = unapply(Array.prototype.map);
 
+const MapEntries = unapply(Map.prototype.entries);
+
 export {
     ErrorCreate,
     ProxyRevocable,
@@ -45,6 +47,7 @@ export {
     WeakMapSet,
     hasOwnProperty,
     map,
+    MapEntries,
 };
 
 export function unapply(func: Function): Function {


### PR DESCRIPTION
Minor change to use a util for getting the entries of a map and avoid `.` calls.