### PR TITLE
fixes #64: preserving distortion capability for global property accessors

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -154,7 +154,7 @@ export class SecureEnvironment implements MembraneBroker {
                 if (isFunction(originalGetter)) {
                     const originalOrDistortedGetter: () => any = WeakMapGet(this.distortionMap, originalGetter) || originalGetter;
                     if (!isProxyTarget(originalOrDistortedGetter)) {
-                        // TODO: needs to be resilience, cannot just throw, what should we do instead?
+                        // TODO: needs to be resilient, cannot just throw, what should we do instead?
                         throw ErrorCreate(`Invalid distortion.`);
                     }
                     currentGetter = function(this: any): SecureValue {

--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -154,7 +154,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         const distortedTarget = WeakMapGet(distortionMap, target) as SecureProxyTarget;
         if (!isProxyTarget(distortedTarget)) {
             // TODO: needs to be resilience, cannot just throw, what should we do instead?
-            throw ErrorCreate(`Invalid distortion mechanism.`);
+            throw ErrorCreate(`Invalid distortion.`);
         }
         return distortedTarget;
     }

--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -153,7 +153,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         // if a distortion entry is found, it must be a valid proxy target
         const distortedTarget = WeakMapGet(distortionMap, target) as SecureProxyTarget;
         if (!isProxyTarget(distortedTarget)) {
-            // TODO: needs to be resilience, cannot just throw, what should we do instead?
+            // TODO: needs to be resilient, cannot just throw, what should we do instead?
             throw ErrorCreate(`Invalid distortion.`);
         }
         return distortedTarget;

--- a/test/distortions/getter.spec.js
+++ b/test/distortions/getter.spec.js
@@ -1,12 +1,16 @@
 import createSecureEnvironment from '../../lib/browser-realm.js';
 
 // getting reference to the function to be distorted
-const { get } = Object.getOwnPropertyDescriptor(ShadowRoot.prototype, 'host');
+const { get: hostGetter } = Object.getOwnPropertyDescriptor(ShadowRoot.prototype, 'host');
+const { get: localStorageGetter } = Object.getOwnPropertyDescriptor(window, 'localStorage');
 
 const distortionMap = new Map([
-    [get, () => {
+    [hostGetter, () => {
         return null;
     }],
+    [localStorageGetter, () => {
+        return 'distorted localStorage';
+    }]
 ]);
 
 const evalScript = createSecureEnvironment(distortionMap);
@@ -28,5 +32,12 @@ describe('Getter Function Distortion', () => {
             const hostGetter = Object.getOwnPropertyDescriptor(ShadowRoot.prototype, 'host').get;
             expect(hostGetter.call(elm)).toBe(null);     
         `); 
+    });
+    it('should work for global property accessors (issue #64)', function () {
+        // expect.assertions(1);
+        evalScript(`
+            const elm = localStorage;
+            expect(localStorage).toBe('distorted localStorage');
+        `);
     });
 });

--- a/test/distortions/getter.spec.js
+++ b/test/distortions/getter.spec.js
@@ -30,7 +30,7 @@ describe('Getter Function Distortion', () => {
             const elm = document.createElement('div');
             elm.attachShadow({ mode: 'open' });
             const hostGetter = Object.getOwnPropertyDescriptor(ShadowRoot.prototype, 'host').get;
-            expect(hostGetter.call(elm)).toBe(null);     
+            expect(hostGetter.call(elm)).toBe(null);
         `); 
     });
     it('should work for global property accessors (issue #64)', function () {

--- a/test/distortions/getter.spec.js
+++ b/test/distortions/getter.spec.js
@@ -36,7 +36,6 @@ describe('Getter Function Distortion', () => {
     it('should work for global property accessors (issue #64)', function () {
         // expect.assertions(1);
         evalScript(`
-            const elm = localStorage;
             expect(localStorage).toBe('distorted localStorage');
         `);
     });


### PR DESCRIPTION
The bug identified by @dejang and Ted is the result of having a different behavior for global descriptors, where the getter of any global descriptor (of globalThis) will not get distorted. This PR fixes that, but I will argue that eventually we should look for a solution that doesn't require a different code-path for global descriptors vs other descriptors.