### PR TITLE
[refactor] relaxing the semantics of the reverse proxies to allow live objects

### DIFF
--- a/src/__tests__/freezing.spec.ts
+++ b/src/__tests__/freezing.spec.ts
@@ -73,18 +73,31 @@ describe('Freezing', () => {
         });
     });
     describe('reverse proxies', () => {
-        it('should be frozen', () => {
-            expect.assertions(4);
+        it('can be freeze', () => {
+            expect.assertions(8);
             globalThis.outerObjectFactory = function (o: any, f: () => void) {
+                expect(Object.isFrozen(o)).toBe(false);
+                expect(Object.isFrozen(f)).toBe(false);
+                Object.freeze(o);
+                Object.freeze(f);
                 expect(Object.isFrozen(o)).toBe(true);
-                expect(Object.isFrozen(Object.getOwnPropertyDescriptor(o, 'y')!.get)).toBe(true);
                 expect(Object.isFrozen(f)).toBe(true);
                 expect(() => {
                     o.z = 3;
                 }).toThrowError();
             }
             const evalScript = createSecureEnvironment();
-            evalScript(`outerObjectFactory({ x: 1, get y() { return 2 } }, function() {})`);
+            evalScript(`
+                'use strict';
+                const o = { x: 1 };
+                const f = function() {};
+                outerObjectFactory(o, f);
+                expect(Object.isFrozen(o)).toBe(true);
+                expect(Object.isFrozen(f)).toBe(true);
+                expect(() => {
+                    o.z = 3;
+                }).toThrowError();
+            `);
         });
     });
 });

--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -128,7 +128,7 @@ export default function createSecureEnvironment(distortionMap?: Map<SecureProxyT
                 // the constructor must be registered (done during construction of env)
                 // otherwise we need to fallback to a regular error.
                 rawError = construct(rawErrorConstructor as RawFunction, [message]);
-            } catch (ignored) {
+            } catch {
                 // in case the constructor inference fails
                 rawError = ErrorCreate(message);
             }

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -37,7 +37,7 @@ export default function createSecureEnvironment(distortionMap?: Map<SecureProxyT
                 // the constructor must be registered (done during construction of env)
                 // otherwise we need to fallback to a regular error.
                 rawError = construct(rawErrorConstructor as RawFunction, [message]);
-            } catch (ignored) {
+            } catch {
                 // in case the constructor inference fails
                 rawError = ErrorCreate(message);
             }

--- a/src/raw-value.ts
+++ b/src/raw-value.ts
@@ -135,7 +135,7 @@ export function reverseProxyFactory(env: MembraneBroker) {
     }
 
     function lockShadowTarget(shadowTarget: ReverseShadowTarget, originalTarget: ReverseProxyTarget) {
-        // todo: leaking symbols
+        // TODO [#60]: leaking symbols
         const targetKeys = ownKeys(originalTarget);
         for (let i = 0, len = targetKeys.length; i < len; i += 1) {
             const key = targetKeys[i];
@@ -159,7 +159,7 @@ export function reverseProxyFactory(env: MembraneBroker) {
         }
         get(shadowTarget: ReverseShadowTarget, key: PropertyKey, receiver: RawObject): SecureValue {
             const { target } = this;
-            // todo: leaking key as symbol
+            // TODO [#60]: leaking key as symbol
             const desc = getPropertyDescriptor(target, key);
             if (isUndefined(desc)) {
                 return desc;
@@ -174,8 +174,7 @@ export function reverseProxyFactory(env: MembraneBroker) {
         }
         set(shadowTarget: ReverseShadowTarget, key: PropertyKey, value: RawValue, receiver: RawObject): boolean {
             const { target } = this;
-            // todo: leaking key as symbol
-            const secValue = env.getSecureValue(value);
+            // TODO [#60]: leaking key as symbol
             const secDesc = getPropertyDescriptor(target, key);
             if (!isUndefined(secDesc)) {
                 // descriptor exists in the target or proto chain
@@ -201,12 +200,12 @@ export function reverseProxyFactory(env: MembraneBroker) {
                 return false;
             }
             // the descriptor is writable on the obj or proto chain, just assign it
-            target[key] = secValue;
+            target[key] = env.getSecureValue(value);
             return true;
         }
         deleteProperty(shadowTarget: ReverseShadowTarget, key: PropertyKey): boolean {
             const { target } = this;
-            // todo: leaking key as symbol
+            // TODO [#60]: leaking key as symbol
             return deleteProperty(target, key);
         }
         apply(shadowTarget: ReverseShadowTarget, rawThisArg: RawValue, rawArgArray: RawValue[]): RawValue {
@@ -270,12 +269,12 @@ export function reverseProxyFactory(env: MembraneBroker) {
         }
         has(shadowTarget: ReverseShadowTarget, key: PropertyKey): boolean {
             const { target } = this;
-            // todo: protect against leaking symbols
+            // TODO [#60]: protect against leaking symbols
             return key in target;
         }
         ownKeys(shadowTarget: ReverseShadowTarget): PropertyKey[] {
             const { target } = this;
-            // todo: protect against leaking symbols
+            // TODO [#60]: protect against leaking symbols
             return ownKeys(target);
         }
         isExtensible(shadowTarget: ReverseShadowTarget): boolean {
@@ -291,7 +290,7 @@ export function reverseProxyFactory(env: MembraneBroker) {
         }
         getOwnPropertyDescriptor(shadowTarget: ReverseShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
             const { target } = this;
-            // todo: leaking key as symbol
+            // TODO [#60]: leaking key as symbol
             let rawDesc = ReflectGetOwnPropertyDescriptor(shadowTarget, key);
             if (!isUndefined(rawDesc)) {
                 return rawDesc;
@@ -330,7 +329,7 @@ export function reverseProxyFactory(env: MembraneBroker) {
         }
         defineProperty(shadowTarget: ReverseShadowTarget, key: PropertyKey, rawPartialDesc: PropertyDescriptor): boolean {
             const { target } = this;
-            // todo: key could be a symbol, and leaked
+            // TODO [#60]: key could be a symbol, and leaked
             if (ReflectDefineProperty(target, key, getSecurePartialDescriptor(rawPartialDesc))) {
                 // intentionally testing against true since it could be undefined as well
                 if (rawPartialDesc.configurable !== true) {

--- a/src/raw-value.ts
+++ b/src/raw-value.ts
@@ -5,21 +5,19 @@ import {
     ReflectSetPrototypeOf,
     freeze,
     isFunction,
-    hasOwnProperty,
     ObjectCreate,
     isUndefined,
     ReflectGetOwnPropertyDescriptor,
-    isTrue,
     ReflectDefineProperty,
     ErrorCreate,
-    ReflectIsExtensible,
-    isSealed,
-    isFrozen,
-    getOwnPropertyDescriptors,
     ReflectGetPrototypeOf,
     map,
     isNullish,
     unconstruct,
+    ownKeys,
+    ReflectIsExtensible,
+    ReflectPreventExtensions,
+    deleteProperty,
 } from './shared';
 import {
     ReverseProxyTarget,
@@ -28,7 +26,6 @@ import {
     SecureConstructor,
     SecureFunction,
     ReverseShadowTarget,
-    SecureProxyTarget,
     ReverseProxy,
     RawFunction,
     SecureArray,
@@ -36,7 +33,6 @@ import {
     SecureValue,
     MembraneBroker,
     SecureObject,
-    TargetMeta,
 } from './types';
 
 function renameFunction(provider: (...args: any[]) => any, receiver: (...args: any[]) => any) {
@@ -67,51 +63,7 @@ function isProxyTarget(o: RawValue): o is (SecureFunction | SecureConstructor | 
 const ProxyRevocable = Proxy.revocable;
 const ProxyCreate = unconstruct(Proxy);
 const { isArray: isArrayOrNotOrThrowForRevoked } = Array;
-
-function installDescriptorIntoShadowTarget(shadowTarget: SecureProxyTarget | ReverseProxyTarget, key: PropertyKey, originalDescriptor: PropertyDescriptor) {
-    const shadowTargetDescriptor = ReflectGetOwnPropertyDescriptor(shadowTarget, key);
-    if (!isUndefined(shadowTargetDescriptor)) {
-        if (hasOwnProperty(shadowTargetDescriptor, 'configurable') &&
-                isTrue(shadowTargetDescriptor.configurable)) {
-            ReflectDefineProperty(shadowTarget, key, originalDescriptor);
-        } else if (hasOwnProperty(shadowTargetDescriptor, 'writable') &&
-                isTrue(shadowTargetDescriptor.writable)) {
-            // just in case
-            shadowTarget[key] = originalDescriptor.value;
-        } else {
-            // ignoring... since it is non configurable and non-writable
-            // usually, arguments, callee, etc.
-        }
-    } else {
-        ReflectDefineProperty(shadowTarget, key, originalDescriptor);
-    }
-}
-
-function getTargetMeta(target: SecureProxyTarget | ReverseProxyTarget): TargetMeta {
-    const meta: TargetMeta = ObjectCreate(null);
-    try {
-        // a revoked proxy will break the membrane when reading the meta
-        meta.proto = ReflectGetPrototypeOf(target);
-        meta.descriptors = getOwnPropertyDescriptors(target);
-        if (isFrozen(target)) {
-            meta.isFrozen = meta.isSealed = meta.isExtensible = true;
-        } else if (isSealed(target)) {
-            meta.isSealed = meta.isExtensible = true;
-        } else if (ReflectIsExtensible(target)) {
-            meta.isExtensible = true;
-        }
-    } catch (_ignored) {
-        // intentionally swallowing the error because this method is just extracting the metadata
-        // in a way that it should always succeed except for the cases in which the target is a proxy
-        // that is either revoked or has some logic that is incompatible with the membrane, in which
-        // case we will just create the proxy for the membrane but revoke it right after to prevent
-        // any leakage.
-        meta.proto = null;
-        meta.descriptors = {};
-        meta.isBroken = true;
-    }
-    return meta;
-}
+const emptyArray: [] = [];
 
 function createReverseShadowTarget(target: ReverseProxyTarget): ReverseShadowTarget {
     let shadowTarget;
@@ -131,64 +83,137 @@ function createReverseShadowTarget(target: ReverseProxyTarget): ReverseShadowTar
     return shadowTarget;
 }
 
+// equivalent to Object.getOwnPropertyDescriptor, but looks into the whole proto chain
+function getPropertyDescriptor(o: any, p: PropertyKey): PropertyDescriptor | undefined {
+    do {
+        const d = ReflectGetOwnPropertyDescriptor(o, p);
+        if (!isUndefined(d)) {
+            ReflectSetPrototypeOf(d, null);
+            return d;
+        }
+        o = ReflectGetPrototypeOf(o);
+    } while (o !== null);
+    return undefined;
+}
+
 export function reverseProxyFactory(env: MembraneBroker) {
 
-    function getReverseDescriptor(descriptor: PropertyDescriptor): PropertyDescriptor {
-        const reverseDescriptor = assign(ObjectCreate(null), descriptor);
-        const { value, get, set } = reverseDescriptor;
-        if ('writable' in reverseDescriptor) {
+    function getRawDescriptor(secDesc: PropertyDescriptor): PropertyDescriptor {
+        const rawDesc = assign(ObjectCreate(null), secDesc);
+        const { value, get, set } = rawDesc;
+        if ('writable' in rawDesc) {
             // we are dealing with a value descriptor
-            reverseDescriptor.value = isFunction(value) ?
+            rawDesc.value = isFunction(value) ?
                 // we are dealing with a method (optimization)
                 getRawFunction(value) : getRawValue(value);
         } else {
             // we are dealing with accessors
             if (isFunction(set)) {
-                reverseDescriptor.set = getRawFunction(set);
+                rawDesc.set = getRawFunction(set);
             }
             if (isFunction(get)) {
-                reverseDescriptor.get = getRawFunction(get);
+                rawDesc.get = getRawFunction(get);
             }
         }
-        return reverseDescriptor;
+        return rawDesc;
     }
 
-    function copyReverseOwnDescriptors(shadowTarget: ReverseShadowTarget, descriptors: PropertyDescriptorMap) {
-        for (const key in descriptors) {
-            // avoid poisoning by checking own properties from descriptors
-            if (hasOwnProperty(descriptors, key)) {
-                const originalDescriptor = getReverseDescriptor(descriptors[key]);
-                installDescriptorIntoShadowTarget(shadowTarget, key, originalDescriptor);
+    function getSecureDescriptor(rawPartialDesc: PropertyDescriptor): PropertyDescriptor {
+        const secPartialDesc = assign(ObjectCreate(null), rawPartialDesc);
+        if ('value' in secPartialDesc) {
+            // we are dealing with a value descriptor
+            secPartialDesc.value = env.getSecureValue(secPartialDesc.value);
+        }
+        if ('set' in secPartialDesc) {
+            // we are dealing with accessors
+            secPartialDesc.set = env.getSecureValue(secPartialDesc.set);
+        }
+        if ('get' in secPartialDesc) {
+            secPartialDesc.get = env.getSecureValue(secPartialDesc.get);
+        }
+        return secPartialDesc;
+    }
+
+    function lockShadowTarget(shadowTarget: ReverseShadowTarget, originalTarget: ReverseProxyTarget) {
+        // todo: leaking symbols
+        const targetKeys = ownKeys(originalTarget);
+        for (let i = 0, len = targetKeys.length; i < len; i += 1) {
+            const key = targetKeys[i];
+            const rawDesc = ReflectGetOwnPropertyDescriptor(shadowTarget, key);
+            if (isUndefined(rawDesc) || rawDesc.configurable === true) {
+                const secDesc = ReflectGetOwnPropertyDescriptor(originalTarget, key) as PropertyDescriptor;
+                ReflectDefineProperty(shadowTarget, key, getRawDescriptor(secDesc));
             }
         }
+        ReflectPreventExtensions(shadowTarget);
     }
 
     class ReverseProxyHandler implements ProxyHandler<ReverseProxyTarget> {
         // original target for the proxy
         private readonly target: ReverseProxyTarget;
-        // metadata about the shape of the target
-        private readonly meta: TargetMeta;
 
-        constructor(target: ReverseProxyTarget, meta: TargetMeta) {
+        constructor(target: ReverseProxyTarget) {
             this.target = target;
-            this.meta = meta;
-        }
-        initialize(shadowTarget: ReverseShadowTarget) {
-            const { meta } = this;
-            // adjusting the proto chain of the shadowTarget (recursively)
-            const rawProto = env.getRawValue(meta.proto);
-            ReflectSetPrototypeOf(shadowTarget, rawProto);
-            // defining own descriptors
-            copyReverseOwnDescriptors(shadowTarget, meta.descriptors);
-            // reserve proxies are always frozen
-            freeze(shadowTarget);
             // future optimization: hoping that proxies with frozen handlers can be faster
             freeze(this);
         }
-        apply(shadowTarget: ReverseShadowTarget, thisArg: RawValue, argArray: RawValue[]): RawValue {
+        get(shadowTarget: ReverseShadowTarget, key: PropertyKey, receiver: RawObject): SecureValue {
             const { target } = this;
-            const secThisArg = env.getSecureValue(thisArg);
-            const secArgArray = env.getSecureValue(argArray);
+            // todo: leaking key as symbol
+            const desc = getPropertyDescriptor(target, key);
+            if (isUndefined(desc)) {
+                return desc;
+            }
+            const { get } = desc;
+            if (isFunction(get)) {
+                // calling the getter with the raw receiver because the getter expects a raw value
+                // it also returns a raw value
+                return apply(env.getRawValue(get), receiver, emptyArray);
+            }
+            return env.getRawValue(desc.value);
+        }
+        set(shadowTarget: ReverseShadowTarget, key: PropertyKey, value: RawValue, receiver: RawObject): boolean {
+            const { target } = this;
+            // todo: leaking key as symbol
+            const secValue = env.getSecureValue(value);
+            const secDesc = getPropertyDescriptor(target, key);
+            if (!isUndefined(secDesc)) {
+                const rawDesc = getRawDescriptor(secDesc);
+                // descriptor exists in the target or proto chain
+                const { set, get, writable } = rawDesc;
+                if (writable === false) {
+                    // TypeError: Cannot assign to read only property '${key}' of object
+                    return false;
+                }
+                if (isFunction(set)) {
+                    // a setter is available, just call it with the raw value because
+                    // the setter expects a raw value
+                    apply(set, receiver, [value]);
+                    return true;
+                }
+                if (isFunction(get)) {
+                    // a getter without a setter should fail to set in strict mode
+                    // TypeError: Cannot set property ${key} of object which has only a getter
+                    return false;
+                }
+            } else if (!ReflectIsExtensible(shadowTarget)) {
+                // non-extensible should throw in strict mode
+                // TypeError: Cannot add property ${key}, object is not extensible
+                return false;
+            }
+            // the descriptor is writable on the obj or proto chain, just assign it
+            target[key] = secValue;
+            return true;
+        }
+        deleteProperty(shadowTarget: ReverseShadowTarget, key: PropertyKey): boolean {
+            const { target } = this;
+            // todo: leaking key as symbol
+            return deleteProperty(target, key);
+        }
+        apply(shadowTarget: ReverseShadowTarget, rawThisArg: RawValue, rawArgArray: RawValue[]): RawValue {
+            const { target } = this;
+            const secThisArg = env.getSecureValue(rawThisArg);
+            const secArgArray = env.getSecureValue(rawArgArray);
             let sec;
             try {
                 sec = apply(target as SecureFunction, secThisArg, secArgArray);
@@ -213,13 +238,13 @@ export function reverseProxyFactory(env: MembraneBroker) {
             }
             return env.getRawValue(sec);
         }
-        construct(shadowTarget: ReverseShadowTarget, argArray: RawValue[], newTarget: RawObject): RawObject {
+        construct(shadowTarget: ReverseShadowTarget, rawArgArray: RawValue[], rawNewTarget: RawObject): RawObject {
             const { target: SecCtor } = this;
-            if (newTarget === undefined) {
+            if (rawNewTarget === undefined) {
                 throw TypeError();
             }
-            const secArgArray = env.getSecureValue(argArray);
-            const secNewTarget = env.getSecureValue(newTarget);
+            const secArgArray = env.getSecureValue(rawArgArray);
+            const secNewTarget = env.getSecureValue(rawNewTarget);
             let sec;
             try {
                 sec = construct(SecCtor as SecureConstructor, secArgArray, secNewTarget);
@@ -243,6 +268,73 @@ export function reverseProxyFactory(env: MembraneBroker) {
                 throw rawError;
             }
             return env.getRawValue(sec);
+        }
+        has(shadowTarget: ReverseShadowTarget, key: PropertyKey): boolean {
+            const { target } = this;
+            // todo: protect against leaking symbols
+            return key in target;
+        }
+        ownKeys(shadowTarget: ReverseShadowTarget): PropertyKey[] {
+            const { target } = this;
+            // todo: protect against leaking symbols
+            return ownKeys(target);
+        }
+        isExtensible(shadowTarget: ReverseShadowTarget): boolean {
+            if (!ReflectIsExtensible(shadowTarget)) {
+                return false;
+            }
+            const { target } = this;
+            if (!ReflectIsExtensible(target)) {
+                lockShadowTarget(shadowTarget, target);
+                return false;
+            }
+            return true;
+        }
+        getOwnPropertyDescriptor(shadowTarget: ReverseShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
+            const { target } = this;
+            // todo: leaking key as symbol
+            let rawDesc = ReflectGetOwnPropertyDescriptor(shadowTarget, key);
+            if (!isUndefined(rawDesc)) {
+                return rawDesc;
+            }
+            const secDesc = ReflectGetOwnPropertyDescriptor(target, key);
+            if (isUndefined(secDesc)) {
+                return secDesc;
+            }
+            rawDesc = getRawDescriptor(secDesc);
+            if (secDesc.configurable == false) {
+                // updating the descriptor to non-configurable on the shadow
+                ReflectDefineProperty(shadowTarget, key, rawDesc);
+            }
+            return rawDesc;
+        }
+        getPrototypeOf(shadowTarget: ReverseShadowTarget): RawValue {
+            const { target } = this;
+            return env.getRawValue(ReflectGetPrototypeOf(target));
+        }
+        setPrototypeOf(shadowTarget: ReverseShadowTarget, prototype: RawValue): boolean {
+            const { target } = this;
+            return ReflectSetPrototypeOf(target, env.getSecureValue(prototype));
+        }
+        preventExtensions(shadowTarget: ReverseShadowTarget): boolean {
+            if (ReflectIsExtensible(shadowTarget)) {
+                const { target } = this;
+                lockShadowTarget(shadowTarget, target);
+                ReflectPreventExtensions(target);
+            }
+            return true;
+        }
+        defineProperty(shadowTarget: ReverseShadowTarget, key: PropertyKey, rawDesc: PropertyDescriptor): boolean {
+            const { target } = this;
+            // todo: key could be a symbol, and leaked
+            if (ReflectDefineProperty(target, key, getSecureDescriptor(rawDesc))) {
+                // intentionally testing against true since it could be undefined as well
+                if (rawDesc.configurable !== true) {
+                    // defining the descriptor to non-configurable on the shadow target
+                    ReflectDefineProperty(shadowTarget, key, rawDesc);
+                }
+            }
+            return true;
         }
     }
 
@@ -270,6 +362,12 @@ export function reverseProxyFactory(env: MembraneBroker) {
     function getRawFunction(fn: SecureFunction): RawFunction {
         const raw = env.getRawRef(fn);
         if (isUndefined(raw)) {
+            try {
+                // just in case the fn is a revoked proxy (extra protection)
+                isArrayOrNotOrThrowForRevoked(fn);
+            } catch (ignored) {
+                return getRevokedReverseProxy(fn) as RawFunction;
+            }
             return createReverseProxy(fn) as RawFunction;
         }
         return raw as SecureFunction;
@@ -289,16 +387,10 @@ export function reverseProxyFactory(env: MembraneBroker) {
     }
 
     function createReverseProxy(sec: ReverseProxyTarget): ReverseProxy {
-        const meta = getTargetMeta(sec);
-        if (meta.isBroken) {
-            return getRevokedReverseProxy(sec);
-        }
         const shadowTarget = createReverseShadowTarget(sec);
-        const proxyHandler = new ReverseProxyHandler(sec, meta);
+        const proxyHandler = new ReverseProxyHandler(sec);
         const proxy = ProxyCreate(shadowTarget, proxyHandler);
         env.createSecureRecord(sec, proxy);
-        // eager initialization of reverse proxies
-        proxyHandler.initialize(shadowTarget);
         return proxy;
     }
 

--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -452,12 +452,12 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
             // this operation can only affect the env object graph
             return preventExtensions(shadowTarget);
         }
-        defineProperty(shadowTarget: SecureShadowTarget, key: PropertyKey, descriptor: PropertyDescriptor): boolean {
+        defineProperty(shadowTarget: SecureShadowTarget, key: PropertyKey, secPartialDesc: PropertyDescriptor): boolean {
             this.initialize(shadowTarget);
             // this operation can only affect the env object graph
             // intentionally using Object.defineProperty instead of Reflect.defineProperty
             // to throw for existing non-configurable descriptors.
-            ObjectDefineProperty(shadowTarget, key, descriptor);
+            ObjectDefineProperty(shadowTarget, key, secPartialDesc);
             return true;
         }
     }

--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -115,7 +115,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         let isRawArray = false;
         try {
             isRawArray = isArrayOrNotOrThrowForRevoked(raw);
-        } catch (ignored) {
+        } catch {
             // raw was revoked - but we call createSecureProxy to support distortions
             return createSecureProxy(raw);
         }
@@ -379,7 +379,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
                     // the secure constructor must be registered (done during construction of env)
                     // otherwise we need to fallback to a regular error.
                     secError = construct(secErrorConstructor as SecureFunction, [message]);
-                } catch (ignored) {
+                } catch {
                     // in case the constructor inference fails
                     secError = new Error(message);
                 }
@@ -411,7 +411,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
                     // the secure constructor must be registered (done during construction of env)
                     // otherwise we need to fallback to a regular error.
                     secError = construct(secErrorConstructor as SecureFunction, [message]);
-                } catch (ignored) {
+                } catch {
                     // in case the constructor inference fails
                     secError = new Error(message);
                 }
@@ -471,7 +471,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
             // this is never invoked just needed to anchor the realm for errors
             try {
                 shadowTarget = 'prototype' in raw ? function () {} : () => {};
-            } catch (ignored) {
+            } catch {
                 // TODO: target is a revoked proxy. This could be optimized if Meta becomes available here.
                 shadowTarget = () => {};
             }

--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -116,7 +116,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         try {
             isRawArray = isArrayOrNotOrThrowForRevoked(raw);
         } catch (ignored) {
-            // raw was revoked
+            // raw was revoked - but we call createSecureProxy to support distortions
             return createSecureProxy(raw);
         }
         if (isRawArray) {
@@ -387,16 +387,16 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
             }
             return getSecureValue(raw);
         }
-        construct(shadowTarget: SecureShadowTarget, argArray: SecureValue[], newTarget: SecureObject): SecureObject {
+        construct(shadowTarget: SecureShadowTarget, secArgArray: SecureValue[], secNewTarget: SecureObject): SecureObject {
             const { target: rawCons } = this;
             this.initialize(shadowTarget);
-            if (isUndefined(newTarget)) {
+            if (isUndefined(secNewTarget)) {
                 throw TypeError();
             }
             let raw;
             try {
-                const rawNewTarget = rawEnv.getRawValue(newTarget);
-                const rawArgArray = rawEnv.getRawValue(argArray);
+                const rawNewTarget = rawEnv.getRawValue(secNewTarget);
+                const rawArgArray = rawEnv.getRawValue(secArgArray);
                 raw = rawConstructHook(rawCons as RawConstructor, rawArgArray, rawNewTarget);
             } catch (e) {
                 // This error occurred when the sandbox attempts to new a

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -21,6 +21,7 @@ export const {
     getOwnPropertyDescriptor: ReflectGetOwnPropertyDescriptor,
     ownKeys,
     preventExtensions: ReflectPreventExtensions,
+    deleteProperty,
 } = Reflect;
 
 const ErrorCreate = unconstruct(Error);

--- a/test/dom/custom-element.spec.js
+++ b/test/dom/custom-element.spec.js
@@ -40,6 +40,18 @@ describe('Outer Realm Custom Element', () => {
             expect(elm instanceof ExtenalElement).toBe(true);
         `);
     });
+    it('should be extensible and can be new from within the sandbox', function() {
+        // expect.assertions(3);
+        evalScript(`
+            const ExtenalElement = customElements.get('x-external');
+            class Baz extends ExtenalElement {}
+            customElements.define('x-baz', Baz);
+            const elm = new Baz();
+            expect(elm.identity()).toBe('ExternalElement');
+            expect(elm instanceof Baz).toBe(true);
+            expect(elm instanceof ExtenalElement).toBe(true);
+        `);
+    });
     it('should get access to external registered elements', function() {
         // expect.assertions(1);
         evalScript(`

--- a/test/membrane/internal-slot-protection.spec.js
+++ b/test/membrane/internal-slot-protection.spec.js
@@ -1,0 +1,26 @@
+import createSecureEnvironment from '../../lib/browser-realm.js';
+
+describe('membrane', () => {
+    it('should prevent attacks that are changing the prototype for impersonation', function() {
+        // expect.assertions(4);
+        const { set } = Object.getOwnPropertyDescriptor(Element.prototype, 'setAttribute');
+        const evalScript = createSecureEnvironment(new Map(set, function (attributeName, value) {
+            expect(attributeName).toBe('rel');
+            expect(value).toBe('import');
+            expect(this instanceof HTMLLinkElement).toBeTrue();
+        }));
+        evalScript(`
+            'use strict';
+
+            const originalProto = HTMLLinkElement.prototype;
+            const link = document.createElement('link');
+            link.__proto__ = HTMLElement.prototype;
+            link.setAttribute('rel', 'import');
+
+            // this attack is trying to change the proto chain, and therefore the instanceof checks and such on distortions,
+            // but it doesn't work because the object graph mutation for the prototype is only visible inside the sandbox.
+            link.setAttribute('rel', 'import');
+            expect(link.rel).toBe(undefined);
+        `);
+    });
+});


### PR DESCRIPTION
This PR introduces a new way to control reverse proxies (proxies accessible on the outer realm for objects that were declared inside a sandbox), and here are the details:

### Motivations

* LWC freezes (in dev-mode) the custom elements declared inside a sandbox.
* any metaprogramming (e.g.: decorators) will attempt to decorate a class/prototype from a sandbox.
* any DOM api that observes changes in objects (e.g.: console.log) was not updating the values due to the snapshotting of the values in the membrane.

This PR relaxes that by supporting live objects via reverse proxies.

### Pros

* LWC components can work with new locker.
* it is easier to debug code using `console.log` statements.
* it is faster to create proxy objects since we don't take the initial snapshot anymore.

### Cons

* poisoning is now easier to achieve, the sandboxed code can attempt to provide objects that have weird behaviors by relying on the live aspect of the reverse proxy. this doesn't seem to be a deal breaker though, mostly because: a) it was not impossible with the previous implementation (getters allowed you to achieve the same) and b) the error boundary now protects against any kind of trickery to gain access to objects that you should not gain access to.
* the new proxy handler is more complicated since it does a lot more work now.