### PR TITLE
make target functions that more closely mimic their raw functions

### DIFF
--- a/src/raw-value.ts
+++ b/src/raw-value.ts
@@ -117,7 +117,7 @@ function createReverseShadowTarget(target: ReverseProxyTarget): ReverseShadowTar
     let shadowTarget;
     if (isFunction(target)) {
         // this is never invoked just needed to anchor the realm
-        shadowTarget = function () {};
+        shadowTarget = 'prototype' in target ? function () {} : () => {};
         renameFunction(target as (...args: any[]) => any, shadowTarget as (...args: any[]) => any);
     } else {
         // o is object

--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -462,13 +462,14 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         }
     }
     
+
     setPrototypeOf(SecureProxyHandler.prototype, null);
 
     function createSecureShadowTarget(raw: SecureProxyTarget): SecureShadowTarget {
         let shadowTarget;
         if (isFunction(raw)) {
             // this is never invoked just needed to anchor the realm for errors
-            shadowTarget = function () {};
+            shadowTarget = 'prototype' in raw ? function () {} : () => {};
             renameFunction(raw as (...args: any[]) => any, shadowTarget);
         } else {
             // o is object


### PR DESCRIPTION
This makes the shadow target's not have a `'prototype'` if the raw value does not have a `prototype`. It also has a bonus of making them non-constructable too which is generally the case (maybe always the case).