### PR TITLE
issue #67: adding a list of dom APIs that can be reflective

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -155,3 +155,11 @@ export const ReflectiveIntrinsicObjectNames = [
     'EvalError',
     'Error',
 ];
+
+// Some DOM APIs that are doing brand checks for some TypeArrays and others objects,
+// for those, when possible, we just remap them per namespace to avoid crossing the
+// membrane.
+// TODO: review this list
+export const ReflectiveDOMObjectNames = [
+    'crypto'
+];

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -155,11 +155,3 @@ export const ReflectiveIntrinsicObjectNames = [
     'EvalError',
     'Error',
 ];
-
-// Some DOM APIs that are doing brand checks for some TypeArrays and others objects,
-// for those, when possible, we just remap them per namespace to avoid crossing the
-// membrane.
-// TODO: review this list
-export const ReflectiveDOMObjectNames = [
-    'crypto'
-];


### PR DESCRIPTION
In the case of the browser sandbox, crypto to be the first one in the list.

this is a partial solution, assuming that:

1. crypto is not dangerous (or give you any authority)
2. crypto to function even on detached iframes (confirmed)