### PR TITLE
[simplification] removing extra record used to store map between sec and raw refs

### DIFF
--- a/src/raw-value.ts
+++ b/src/raw-value.ts
@@ -380,7 +380,7 @@ export function reverseProxyFactory(env: MembraneBroker) {
     function getRevokedReverseProxy(sec: ReverseProxyTarget): ReverseProxy {
         const shadowTarget = createReverseShadowTarget(sec);
         const { proxy, revoke } = ProxyRevocable(shadowTarget, {});
-        env.createSecureRecord(sec, proxy);
+        env.setRefMapEntries(sec, proxy);
         revoke();
         return proxy;
     }
@@ -389,7 +389,7 @@ export function reverseProxyFactory(env: MembraneBroker) {
         const shadowTarget = createReverseShadowTarget(sec);
         const proxyHandler = new ReverseProxyHandler(sec);
         const proxy = ProxyCreate(shadowTarget, proxyHandler);
-        env.createSecureRecord(sec, proxy);
+        env.setRefMapEntries(sec, proxy);
         return proxy;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,20 +31,13 @@ export interface TargetMeta {
 export type SecureProxy = SecureObject | SecureFunction;
 export type ReverseProxy = RawObject | RawFunction;
 
-export interface SecureRecord {
-    // Ref to a value created inside the sandbox or a reverse proxy from another sandbox.
-    raw: SecureProxyTarget | ReverseProxy;
-    // Proxy of an reference from the outer realm or from another sandbox.
-    sec: SecureProxy | ReverseProxyTarget;
-}
-
 export type DistortionMap = WeakMap<SecureProxyTarget, SecureProxyTarget>;
 
 export interface MembraneBroker {
-    // secure object map
-    som: WeakMap<SecureFunction | SecureObject, SecureRecord>;
-    // raw object map
-    rom: WeakMap<RawFunction | RawObject, SecureRecord>;
+    // secure ref map to reverse proxy or raw ref
+    som: WeakMap<SecureFunction | SecureObject, SecureProxyTarget | ReverseProxy>;
+    // raw ref map to secure proxy or secure ref
+    rom: WeakMap<RawFunction | RawObject, SecureProxy | ReverseProxyTarget>;
     // raw object distortion map
     distortionMap: DistortionMap;
 
@@ -52,5 +45,5 @@ export interface MembraneBroker {
     getSecureValue(raw: RawValue): SecureValue;
     getRawRef(sec: SecureValue): RawValue | undefined;
     getSecureRef(raw: RawValue): SecureValue | undefined;
-    createSecureRecord(sec: SecureValue, raw: RawValue): void;
+    setRefMapEntries(sec: SecureValue, raw: RawValue): void;
 }


### PR DESCRIPTION
When storing the double entry in the maps, we use a now unnecessary record that holds ref to sec and raw, as the value on both maps. It turns out that the record is not needed, and it can be just a simple map with the crossed references.

This change reduces the memory allocation, and should improve perf as well.