### PR TITLE
fixes #76: document.all == null breaks the membrane for valid targets

### DIFF
--- a/src/raw-value.ts
+++ b/src/raw-value.ts
@@ -183,7 +183,7 @@ export function reverseProxyFactory(env: MembraneBroker) {
         }
         construct(shadowTarget: ReverseShadowTarget, rawArgArray: RawValue[], rawNewTarget: RawObject): RawObject {
             const { target: SecCtor } = this;
-            if (rawNewTarget === undefined) {
+            if (isUndefined(rawNewTarget)) {
                 throw TypeError();
             }
             const secArgArray = env.getSecureValue(rawArgArray);

--- a/src/raw-value.ts
+++ b/src/raw-value.ts
@@ -14,7 +14,7 @@ import {
     ReflectGet,
     ReflectSet,
     map,
-    isNullish,
+    isNullOrUndefined,
     unconstruct,
     ownKeys,
     ReflectIsExtensible,
@@ -34,7 +34,6 @@ import {
     RawArray,
     SecureValue,
     MembraneBroker,
-    SecureObject,
 } from './types';
 
 function renameFunction(provider: (...args: any[]) => any, receiver: (...args: any[]) => any) {
@@ -50,16 +49,6 @@ function renameFunction(provider: (...args: any[]) => any, receiver: (...args: a
     if (!isUndefined(nameDescriptor)) {
         ReflectDefineProperty(receiver, 'name', nameDescriptor);
     }
-}
-
-// it means it does have identity and should be proxified.
-function isProxyTarget(o: RawValue): o is (SecureFunction | SecureConstructor | SecureObject) {
-    // hire-wired for the common case
-    if (isNullish(o)) {
-        return false;
-    }
-    const t = typeof o;
-    return t === 'object' || t === 'function';
 }
 
 const ProxyRevocable = Proxy.revocable;
@@ -285,6 +274,15 @@ export function reverseProxyFactory(env: MembraneBroker) {
     ReflectSetPrototypeOf(ReverseProxyHandler.prototype, null);
 
     function getRawValue(sec: SecureValue): RawValue {
+        if (isNullOrUndefined(sec)) {
+            return sec as RawValue;
+        }
+        const t = typeof sec;
+        // internationally ignoring the case of (typeof document.all === 'undefined') because
+        // in the reserve membrane, you never get one of those exotic objects
+        if (t === 'function') {
+            return getRawFunction(sec);
+        }
         let isSecArray = false;
         try {
             isSecArray = isArrayOrNotOrThrowForRevoked(sec);
@@ -293,7 +291,7 @@ export function reverseProxyFactory(env: MembraneBroker) {
         }
         if (isSecArray) {
             return getRawArray(sec);
-        } else if (isProxyTarget(sec)) {
+        } else if (t === 'object') {
             const raw = env.getRawRef(sec);
             if (isUndefined(raw)) {
                 return createReverseProxy(sec);

--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -102,13 +102,16 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         return obj === undefined;
     }
 
+    function isNull(obj: any): obj is null {
+        return obj === null;
+    }
+
     function isFunction(obj: any): obj is Function {
         return typeof obj === 'function';
     }
 
-    function isNullish(obj: any): obj is null {
-        // eslint-disable-next-line eqeqeq
-        return obj == null;
+    function isNullish(obj: any): obj is (null | undefined) {
+        return isNull(obj) || isUndefined(obj);
     }
 
     function getSecureValue(raw: RawValue): SecureValue {

--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -122,7 +122,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         // `typeof document.all === 'undefined'`, which is an exotic object with
         // a bizarre behavior described here:
         // * https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
-        // This check cover that case, but doesn't affect other unidefined values
+        // This check covers that case, but doesn't affect other undefined values
         // because those are covered by the previous condition anyways.
         if (t === 'function' || t === 'undefined') {
             return getSecureFunction(raw);

--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -20,7 +20,6 @@ import {
     RawConstructor,
     RawFunction,
     RawValue,
-    RawObject,
     RawArray,
     TargetMeta,
     MembraneBroker,
@@ -110,11 +109,24 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         return typeof obj === 'function';
     }
 
-    function isNullish(obj: any): obj is (null | undefined) {
+    function isNullOrUndefined(obj: any): obj is (null | undefined) {
         return isNull(obj) || isUndefined(obj);
     }
 
     function getSecureValue(raw: RawValue): SecureValue {
+        if (isNullOrUndefined(raw)) {
+            return raw as SecureValue;
+        }
+        const t = typeof raw;
+        // NOTE: internationally checking for typeof 'undefined' for the case of
+        // `typeof document.all === 'undefined'`, which is an exotic object with
+        // a bizarre behavior described here:
+        // * https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
+        // This check cover that case, but doesn't affect other unidefined values
+        // because those are covered by the previous condition anyways.
+        if (t === 'function' || t === 'undefined') {
+            return getSecureFunction(raw);
+        }
         let isRawArray = false;
         try {
             isRawArray = isArrayOrNotOrThrowForRevoked(raw);
@@ -124,7 +136,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         }
         if (isRawArray) {
             return getSecureArray(raw);
-        } else if (isProxyTarget(raw)) {
+        } else if (t === 'object') {
             const sec: SecureValue | undefined = WeakMapGet(rom, raw);
             if (isUndefined(sec)) {
                 return createSecureProxy(raw);
@@ -155,21 +167,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         }
         // if a distortion entry is found, it must be a valid proxy target
         const distortedTarget = WeakMapGet(distortionMap, target) as SecureProxyTarget;
-        if (!isProxyTarget(distortedTarget)) {
-            // TODO: needs to be resilient, cannot just throw, what should we do instead?
-            throw ErrorCreate(`Invalid distortion.`);
-        }
         return distortedTarget;
-    }
-
-    // it means it does have identity and should be proxified.
-    function isProxyTarget(o: RawValue | SecureValue): o is (RawFunction | RawConstructor | RawObject) {
-        // hire-wired for the common case
-        if (isNullish(o)) {
-            return false;
-        }
-        const t = typeof o;
-        return t === 'object' || t === 'function';
     }
 
     function renameFunction(rawProvider: (...args: any[]) => any, receiver: (...args: any[]) => any) {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -66,7 +66,7 @@ export function isNull(obj: any): obj is null {
     return obj === null;
 }
 
-export function isNullish(obj: any): obj is (null | undefined) {
+export function isNullOrUndefined(obj: any): obj is (null | undefined) {
     return isNull(obj) || isUndefined(obj);
 }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -62,9 +62,12 @@ export function isUndefined(obj: any): obj is undefined {
     return obj === undefined;
 }
 
-export function isNullish(obj: any): obj is null {
-    // eslint-disable-next-line eqeqeq
-    return obj == null;
+export function isNull(obj: any): obj is null {
+    return obj === null;
+}
+
+export function isNullish(obj: any): obj is (null | undefined) {
+    return isNull(obj) || isUndefined(obj);
 }
 
 export function isTrue(obj: any): obj is true {

--- a/test/membrane/document-all.spec.js
+++ b/test/membrane/document-all.spec.js
@@ -1,0 +1,22 @@
+import createSecureEnvironment from '../../lib/browser-realm.js';
+
+describe('document.all', () => {
+    it('should change the value of its yellow typeof from "undefined" to "object"', function() {
+        // expect.assertions(2);
+        const evalScript = createSecureEnvironment();
+        expect(typeof document.all).toBe("undefined");
+        evalScript(`
+            // observable difference between a regular dom and a sandboxed dom
+            expect(typeof document.all).toBe("object");
+        `);
+    });
+    it('should work throughout the membrane', function() {
+        // expect.assertions(3);
+        const evalScript = createSecureEnvironment();
+        evalScript(`
+            expect(document.all.length > 1).toBeTrue();
+            expect(document.all[0].ownerDocument).toBe(document); // comparison in red
+            expect(document.all[0].ownerDocument === document).toBeTrue(); // comparison in yellow
+        `);
+    });
+});


### PR DESCRIPTION
This PR fixes https://github.com/caridy/secure-javascript-environment/issues/76

* [x] tests (pending)