### PR TITLE
letting engine to optimize typeof comparisons

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -63,9 +63,7 @@ export class SecureEnvironment implements MembraneBroker {
         this.distortionMap = WeakMapCreate();
         // validating distortion entries
         distortionMap?.forEach((value, key) => {
-            const o = typeof key;
-            const d = typeof value;
-            if (o !== d) {
+            if (typeof key !== typeof value) {
                 throw ErrorCreate(`Invalid distortion ${value}.`);
             }
             WeakMapSet(this.distortionMap, key, value);
@@ -175,13 +173,12 @@ export class SecureEnvironment implements MembraneBroker {
                 if (isNullOrUndefined(securePropertyValue)) {
                     continue;
                 }
-                const t = typeof securePropertyValue;
                 // this is the case where the secure env has a descriptor that was supposed to be
                 // overrule but can't be done because it is a non-configurable. Instead we try to
                 // fallback to some more advanced gymnastics
                 if (hasOwnProperty(secureDescriptor, 'value')) {
                     // valid proxy target (intentionally ignoring the case of document.all since it is not a value descriptor)
-                    if (t === 'function' || t === 'object') {
+                    if (typeof securePropertyValue === 'function' || typeof securePropertyValue === 'object') {
                         if (!WeakMapHas(this.som, securePropertyValue)) {
                             // remapping the value of the secure object graph to the outer realm graph
                             const { value: rawDescriptorValue } = rawDescriptor;
@@ -204,7 +201,7 @@ export class SecureEnvironment implements MembraneBroker {
                 } else if (hasOwnProperty(secureDescriptor, 'get')) {
                     // internationally ignoring the case of (typeof document.all === 'undefined') because
                     // it is specified as configurable, you never get one of those exotic objects in this branch
-                    if (t === 'function' || t === 'object') {
+                    if (typeof securePropertyValue === 'function' || typeof securePropertyValue === 'object') {
                         if (securePropertyValue === secureValue[key]) {
                             // this is the case for window.document which is identity preserving getter
                             // const rawDescriptorValue = rawValue[key];

--- a/src/raw-value.ts
+++ b/src/raw-value.ts
@@ -277,10 +277,9 @@ export function reverseProxyFactory(env: MembraneBroker) {
         if (isNullOrUndefined(sec)) {
             return sec as RawValue;
         }
-        const t = typeof sec;
         // internationally ignoring the case of (typeof document.all === 'undefined') because
         // in the reserve membrane, you never get one of those exotic objects
-        if (t === 'function') {
+        if (typeof sec === 'function') {
             return getRawFunction(sec);
         }
         let isSecArray = false;
@@ -291,7 +290,7 @@ export function reverseProxyFactory(env: MembraneBroker) {
         }
         if (isSecArray) {
             return getRawArray(sec);
-        } else if (t === 'object') {
+        } else if (typeof sec === 'object') {
             const raw = env.getRawRef(sec);
             if (isUndefined(raw)) {
                 return createReverseProxy(sec);

--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -117,14 +117,13 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         if (isNullOrUndefined(raw)) {
             return raw as SecureValue;
         }
-        const t = typeof raw;
         // NOTE: internationally checking for typeof 'undefined' for the case of
         // `typeof document.all === 'undefined'`, which is an exotic object with
         // a bizarre behavior described here:
         // * https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
         // This check covers that case, but doesn't affect other undefined values
         // because those are covered by the previous condition anyways.
-        if (t === 'function' || t === 'undefined') {
+        if (typeof raw === 'function' || typeof raw === 'undefined') {
             return getSecureFunction(raw);
         }
         let isRawArray = false;
@@ -136,7 +135,7 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         }
         if (isRawArray) {
             return getSecureArray(raw);
-        } else if (t === 'object') {
+        } else if (typeof raw === 'object') {
             const sec: SecureValue | undefined = WeakMapGet(rom, raw);
             if (isUndefined(sec)) {
                 return createSecureProxy(raw);


### PR DESCRIPTION
Based on some feedback from @ljharb on https://github.com/caridy/secure-javascript-environment/pull/77#discussion_r394397511, we can now validate that in seems that the parser can understand better the intent and optimize the comparison (to avoid string comparison) when the typeof is inline.