### PR TITLE
disabling document.all inside a sandbox

### DIFF
--- a/src/secure-value.ts
+++ b/src/secure-value.ts
@@ -123,7 +123,10 @@ export const serializedSecureEnvSourceText = (function secureEnvFactory(rawEnv: 
         // * https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
         // This check covers that case, but doesn't affect other undefined values
         // because those are covered by the previous condition anyways.
-        if (typeof raw === 'function' || typeof raw === 'undefined') {
+        if (typeof raw === 'undefined') {
+            return undefined;
+        }
+        if (typeof raw === 'function') {
             return getSecureFunction(raw);
         }
         let isRawArray = false;

--- a/test/membrane/document-all.spec.js
+++ b/test/membrane/document-all.spec.js
@@ -1,22 +1,19 @@
 import createSecureEnvironment from '../../lib/browser-realm.js';
 
 describe('document.all', () => {
-    it('should change the value of its yellow typeof from "undefined" to "object"', function() {
+    it('should preserve the typeof it since it is a common test for older browsers', function() {
         // expect.assertions(2);
         const evalScript = createSecureEnvironment();
         expect(typeof document.all).toBe("undefined");
         evalScript(`
-            // observable difference between a regular dom and a sandboxed dom
-            expect(typeof document.all).toBe("object");
+            expect(typeof document.all).toBe("undefined");
         `);
     });
-    it('should work throughout the membrane', function() {
-        // expect.assertions(3);
+    it('should disable the feature entirely inside the sandbox', function() {
+        // expect.assertions(1);
         const evalScript = createSecureEnvironment();
         evalScript(`
-            expect(document.all.length > 1).toBeTrue();
-            expect(document.all[0].ownerDocument).toBe(document); // comparison in red
-            expect(document.all[0].ownerDocument === document).toBeTrue(); // comparison in yellow
+            expect(document.all === undefined).toBeTrue();
         `);
     });
 });


### PR DESCRIPTION
As a follow up from PR https://github.com/caridy/secure-javascript-environment/pull/77, and after reviewing the current usage of this feature:

https://www.chromestatus.com/metrics/feature/timeline/popularity/83

![image](https://user-images.githubusercontent.com/38969/77114802-8d857000-6a03-11ea-8cc5-11f1196ecbec.png)

I have reviewed some of the websites that are using this feature, all of them are just simply relying on the undefined nature of the value to detect something. It seems that the detection of the value being undefined is more important that the feature itself, and for that reason, we should favor the detection. In this PR, we are making the value `undefined` inside the sandbox, which means that you will never be able to access the collection itself, you have others means for that.