### PR TITLE
fix: namespace to namespace class extensions

### DIFF
--- a/src/blue.ts
+++ b/src/blue.ts
@@ -39,7 +39,7 @@ import {
 function renameFunction(provider: RedFunction, receiver: BlueFunction) {
     try {
         // a revoked proxy will break the membrane when reading the function name
-        let nameDescriptor = ReflectGetOwnPropertyDescriptor(provider, 'name')!;
+        const nameDescriptor = ReflectGetOwnPropertyDescriptor(provider, 'name')!;
         ReflectDefineProperty(receiver, 'name', nameDescriptor);
     } catch {
         // intentionally swallowing the error because this method is just extracting the function

--- a/src/blue.ts
+++ b/src/blue.ts
@@ -130,6 +130,15 @@ export function blueProxyFactory(env: MembraneBroker) {
 
         constructor(target: BlueProxyTarget) {
             this.target = target;
+        }
+        initialize(shadowTarget: BlueShadowTarget) {
+            if (isFunction(this.target)) {
+                // correcting the shadowTarget.prototype which is non-configurable
+                // which can mess up with the getOwnPropertyDescriptor trap logic
+                ReflectDefineProperty(shadowTarget, 'prototype', {
+                    value: getBlueValue(this.target.prototype),
+                });
+            }
             // future optimization: hoping that proxies with frozen handlers can be faster
             freeze(this);
         }
@@ -332,6 +341,7 @@ export function blueProxyFactory(env: MembraneBroker) {
         const proxyHandler = new BlueProxyHandler(red);
         const proxy = ProxyCreate(shadowTarget, proxyHandler);
         env.setRefMapEntries(red, proxy);
+        proxyHandler.initialize(shadowTarget);
         return proxy;
     }
 

--- a/src/red.ts
+++ b/src/red.ts
@@ -175,7 +175,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
     function renameFunction(blueProvider: (...args: any[]) => any, receiver: (...args: any[]) => any) {
         try {
             // a revoked proxy will break the membrane when reading the function name
-            let nameDescriptor = getOwnPropertyDescriptor(blueProvider, 'name')!;
+            const nameDescriptor = getOwnPropertyDescriptor(blueProvider, 'name')!;
             defineProperty(receiver, 'name', nameDescriptor);
         } catch {
             // intentionally swallowing the error because this method is just extracting the function

--- a/src/red.ts
+++ b/src/red.ts
@@ -173,17 +173,14 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
     }
 
     function renameFunction(blueProvider: (...args: any[]) => any, receiver: (...args: any[]) => any) {
-        let nameDescriptor: PropertyDescriptor | undefined;
         try {
             // a revoked proxy will break the membrane when reading the function name
-            nameDescriptor = getOwnPropertyDescriptor(blueProvider, 'name');
-        } catch (_ignored) {
+            let nameDescriptor = getOwnPropertyDescriptor(blueProvider, 'name')!;
+            defineProperty(receiver, 'name', nameDescriptor);
+        } catch {
             // intentionally swallowing the error because this method is just extracting the function
             // in a way that it should always succeed except for the cases in which the provider is a proxy
             // that is either revoked or has some logic to prevent reading the name property descriptor.
-        }
-        if (!isUndefined(nameDescriptor)) {
-            defineProperty(receiver, 'name', nameDescriptor);
         }
     }    
 

--- a/test/membrane/cross-ns-extensions.spec.js
+++ b/test/membrane/cross-ns-extensions.spec.js
@@ -1,0 +1,45 @@
+import createSecureEnvironment from '../../lib/browser-realm.js';
+
+class Base {
+    base() {
+        return 'from base';
+    }
+}
+let Foo;
+function saveFoo(f) {
+    Foo = f;
+}
+
+const evalScript = createSecureEnvironment(undefined, { Base, saveFoo });
+evalScript(`
+    class Foo extends Base {
+        foo() {
+            return 'from foo';
+        }
+    }
+    saveFoo(Foo);
+`);
+
+const endowments = {
+    Foo,
+    expect
+};
+
+describe('The membrane', () => {
+    it('should allow expandos on endowments inside the sandbox', function() {
+        // expect.assertions(4);
+        const evalScript = createSecureEnvironment(undefined, endowments);
+        evalScript(`
+            'use strict';
+            expect(Foo.prototype.base()).toBe('from base');
+            expect(Foo.prototype.foo()).toBe('from foo');
+            class Bar extends Foo {
+                foo() {
+                    return 'from bar as override';
+                }
+            }
+            expect(new Bar().base()).toBe('from base');
+            expect(new Bar().foo()).toBe('from bar as override');
+        `);
+    });
+});

--- a/test/membrane/object-semantics.spec.js
+++ b/test/membrane/object-semantics.spec.js
@@ -1,0 +1,49 @@
+import createSecureEnvironment from '../../lib/browser-realm.js';
+
+let obj;
+function saveObject(o) {
+    obj = o;
+}
+
+const endowments = {
+    saveObject,
+    expect
+};
+
+describe('Blue Proxies', () => {
+    it('should be preserved the JS Object semantics by allowing writable objects to change', () => {
+        'use strict';
+        // expect.assertions(9);
+        const evalScript = createSecureEnvironment(undefined, endowments);
+        evalScript(`
+            'use strict';
+            const obj = {
+                mutate() {
+                    Object.defineProperty(this, 'x', {
+                        value: 3,
+                        writable: false,
+                    });
+                }
+            };
+            Object.defineProperty(obj, 'x', {
+                value: 1,
+                writable: true,
+            });
+            saveObject(obj);
+        `);
+        expect(obj.x).toBe(1);
+        expect(Object.getOwnPropertyDescriptor(obj, 'x').value).toBe(1);
+        obj.x = 2;
+        expect(obj.x).toBe(2);
+        expect(Object.getOwnPropertyDescriptor(obj, 'x').value).toBe(2);
+        obj.mutate();
+        obj.x;
+        expect(obj.x).toBe(3);
+        expect(Object.getOwnPropertyDescriptor(obj, 'x').value).toBe(3);
+        expect(() => {
+            obj.x = 4;
+        }).toThrow();
+        expect(obj.x).toBe(3);
+        expect(Object.getOwnPropertyDescriptor(obj, 'x').value).toBe(3);
+    });
+}); 


### PR DESCRIPTION
This PR fixes the issue with namespace to namespace class extensions that were reporting the incorrect prototype value on constructors.

The issue was that when a shadowTarget is a function, it comes by default with two non-configurable, writable properties defined, `name` and `prototype`. In the code, we were always attempting to read the descriptor from the shadowTarget first, and then from the target if it didn't exist in the shadowTarget, and this, of course, was returning the wrong prototype value.

With this PR, we adjust the logic to never ever return the value from a shadowTarget on a blue proxy, instead, we always read the value from the real target, and we use the shadowTarget only to preserve the semantics of the language (the object invariants).

 * [x] tests