### PR TITLE
fix #85: global EventTarget is configurable and can be replaced after remapping its prototype to the sandbox prototype, which is unforgeable

### DIFF
--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -118,7 +118,6 @@ function aggregateGlobalDescriptors(
 
     // removing unforgeable descriptors that cannot be installed
     delete to.location;
-    delete to.EventTarget;
     delete to.document;
     delete to.window;
     // Some DOM APIs do brand checks for TypeArrays and others objects,

--- a/test/dom/unforgeables.spec.js
+++ b/test/dom/unforgeables.spec.js
@@ -1,0 +1,27 @@
+import createSecureEnvironment from '../../lib/browser-realm.js';
+
+const evalScript = createSecureEnvironment(undefined, window);
+
+describe('EventTarget unforgeable', () => {
+    it('should be accessible from window', function() {
+        // expect.assertions(4);
+        evalScript(`
+            expect(EventTarget !== undefined).toBe(true);
+            expect(window.__proto__.__proto__.__proto__ === EventTarget.prototype).toBe(true);
+            expect(document.body instanceof EventTarget).toBe(true);
+            expect(document.createElement('p') instanceof EventTarget).toBe(true);
+        `);
+    });
+});
+
+describe('Window unforgeable', () => {
+    it('should be accessible from window', function() {
+        // expect.assertions(4);
+        evalScript(`
+            expect(Window !== undefined).toBe(true);
+            expect(window.__proto__ === Window.prototype).toBe(true);
+            expect(window instanceof Window).toBe(true);
+            expect(globalThis instanceof Window).toBe(true);
+        `);
+    });
+});


### PR DESCRIPTION
This PR adjust our model to the following:

1. `EventTarget.prototype` continues to be unforgeable (it is accessible from `window.__proto__.__proto__.__proto__`
2. `EventTarget.prototype` gets map to  `EventTarget.prototype`  from the other side.
3. all descriptors in `EventTarget.prototype`  are replaced with proxies to their corresponding blue side.
4. `EventTarget` is replaced with the blue `EventTarget`.

Btw, this issue was affecting chrome only because for some reason, they are deleting the global `EventTarget` when the iframe is detached. Replacing it with a proxy of the blue one fixes that.