### PR TITLE
fixes #63: adding new capability to support live red proxies

### DIFF
--- a/src/__tests__/freezing.spec.ts
+++ b/src/__tests__/freezing.spec.ts
@@ -46,7 +46,7 @@ describe('Freezing', () => {
         });
     });
     describe('after creating the sandbox', () => {
-        it('should not be observed from within the sandbox', function() {
+        it('should not be observed from within the sandbox after a mutation', function() {
             expect.assertions(9);
             globalThis.baz = { a:1, b: 2 };
             const evalScript = createSecureEnvironment(undefined, window);
@@ -55,6 +55,7 @@ describe('Freezing', () => {
                 expect(Object.isExtensible(globalThis.baz)).toBe(true);
                 expect(Object.isSealed(globalThis.baz)).toBe(false);
                 expect(Object.isFrozen(globalThis.baz)).toBe(false);
+                baz.mutation = 1; // this makes the proxy static via snapshot
             `);
             // freezing the blue value after being observed by the sandbox
             Object.freeze(globalThis.baz);

--- a/src/blue.ts
+++ b/src/blue.ts
@@ -135,7 +135,7 @@ export function blueProxyFactory(env: MembraneBroker) {
     }
 
     function getStaticRedArray(blueArray: BlueArray): RedArray {
-        return map(blueArray, (blue: BlueValue) => env.getRedValue(blue));
+        return map(blueArray, env.getRedValue);
     }
 
     class BlueDynamicProxyHandler implements ProxyHandler<BlueProxyTarget> {

--- a/src/red.ts
+++ b/src/red.ts
@@ -352,6 +352,13 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
 
     // reading traps
 
+    /**
+     * This trap cannot just use `Reflect.get` directly on the `target` because
+     * the red object graph might have mutations that are only visible on the red side,
+     * which means looking into `target` directly is not viable. Instead, we need to
+     * implement a more crafty solution that looks into target's own properties, or
+     * in the red proto chain when needed.
+     */
     function redProxyDynamicGetTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey, receiver: RedObject): RedValue {
         /**
          * If the target has a non-configurable own data descriptor that was observed by the red side,
@@ -466,6 +473,13 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         return setPrototypeOf(shadowTarget, prototype);
     }
 
+    /**
+     * This trap cannot just use `Reflect.set` directly on the `target` because
+     * the red object graph might have mutations that are only visible on the red side,
+     * which means looking into `target` directly is not viable. Instead, we need to
+     * implement a more crafty solution that looks into target's own properties, or
+     * in the red proto chain when needed.
+     */
     function redProxyDynamicSetTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey, value: RedValue, receiver: RedObject): boolean {
         const { target } = this;
         const blueDescriptor = getOwnPropertyDescriptor(target, key);

--- a/src/red.ts
+++ b/src/red.ts
@@ -69,6 +69,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         defineProperty,
         get: ReflectGet,
         set: ReflectSet,
+        has: ReflectHas,
     } = Reflect;
     const {
         assign,
@@ -82,7 +83,6 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         hasOwnProperty,
     } = Object;
     const ProxyRevocable = Proxy.revocable;
-    const ProxyCreate = unconstruct(Proxy);
     const { isArray: isArrayOrNotOrThrowForRevoked } = Array;
     const noop = () => undefined;
     const map = unapply(Array.prototype.map);
@@ -115,6 +115,17 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         return isNull(obj) || isUndefined(obj);
     }
 
+    function isMarkAsDynamic(blue: RedProxyTarget): boolean {
+        let hasDynamicMark: boolean = false;
+        try {
+            hasDynamicMark = hasOwnPropertyCall(blue, LockerLiveValueMarkerSymbol);
+        } catch {
+            // try-catching this because blue could be a proxy that is revoked
+            // or throws from the `has` trap.
+        }
+        return hasDynamicMark;
+    }
+
     function getRedValue(blue: BlueValue): RedValue {
         if (isNullOrUndefined(blue)) {
             return blue as RedValue;
@@ -128,60 +139,19 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         if (typeof blue === 'undefined') {
             return undefined;
         }
-        if (typeof blue === 'function') {
-            return getRedFunction(blue);
-        }
-        if (typeof blue === 'object') {
-            const red: RedValue | undefined = WeakMapGet(blueMap, blue);
+        if (typeof blue === 'object' || typeof blue === 'function') {
+            const blueOriginalOrDistortedValue = getDistortedValue(blue);
+            const red: RedValue | undefined = WeakMapGet(blueMap, blueOriginalOrDistortedValue);
             if (!isUndefined(red)) {
                 return red;
             }
-            let hasDynamicMark: boolean = false;
-            try {
-                hasDynamicMark = hasOwnPropertyCall(blue, LockerLiveValueMarkerSymbol);
-            } catch {}
-            if (hasDynamicMark) {
-                return createDynamicRedProxy(blue);
-            }
-            let isBlueArray = false;
-            try {
-                isBlueArray = isArrayOrNotOrThrowForRevoked(blue);
-            } catch {
-                // blue was revoked - but we call createRedProxy to support distortions
-                return createStaticRedProxy(blue);
-            }
-            if (isBlueArray) {
-                return getStaticRedArray(blue);
-            }
-            return createStaticRedProxy(blue);
-        } else {
-            return blue as RedValue;
+            return createRedProxy(blueOriginalOrDistortedValue);
         }
+        return blue as RedValue;
     }
 
     function getStaticBlueArray(redArray: RedArray): BlueArray {
-        return map(redArray, (red: RedValue) => blueEnv.getBlueValue(red));
-    }
-
-    function getStaticRedArray(blueArray: BlueArray): RedArray {
-        // TODO: static arrays have no identity at this point. If the
-        // same array is sent twice, you get two distinct red arrays. 
-        return map(blueArray, (blue: BlueValue) => getRedValue(blue));
-    }
-
-    function getRedFunction(blueFn: BlueFunction): RedFunction {
-        const redFn: RedFunction | undefined = WeakMapGet(blueMap, blueFn);
-        if (isUndefined(redFn)) {
-            let hasDynamicMark: boolean = false;
-            try {
-                hasDynamicMark = hasOwnPropertyCall(blueFn, LockerLiveValueMarkerSymbol);
-            } catch {}
-            if (hasDynamicMark) {
-                return createDynamicRedProxy(blueFn) as RedFunction;
-            }
-            return createStaticRedProxy(blueFn) as RedFunction;
-        }
-        return redFn;
+        return map(redArray, blueEnv.getBlueValue);
     }
 
     function getDistortedValue(target: RedProxyTarget): RedProxyTarget {
@@ -229,16 +199,14 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         const { value: blueValue, get: blueGet, set: blueSet } = redDescriptor;
         if ('writable' in redDescriptor) {
             // we are dealing with a value descriptor
-            redDescriptor.value = isFunction(blueValue) ?
-                // we are dealing with a method (optimization)
-                getRedFunction(blueValue) : getRedValue(blueValue);
+            redDescriptor.value = getRedValue(blueValue);
         } else {
             // we are dealing with accessors
             if (isFunction(blueSet)) {
-                redDescriptor.set = getRedFunction(blueSet);
+                redDescriptor.set = getRedValue(blueSet);
             }
             if (isFunction(blueGet)) {
-                redDescriptor.get = getRedFunction(blueGet);
+                redDescriptor.get = getRedValue(blueGet);
             }
         }
         return redDescriptor;
@@ -256,6 +224,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
 
     function copyBlueDescriptorIntoShadowTarget(shadowTarget: RedShadowTarget, originalTarget: RedProxyTarget, key: PropertyKey) {
         // Note: a property might get defined multiple times in the shadowTarget
+        //       if the user calls defineProperty or similar mechanism multiple times
         //       but it will always be compatible with the previous descriptor
         //       to preserve the object invariants, which makes these lines safe.
         const normalizedBlueDescriptor = getOwnPropertyDescriptor(originalTarget, key);
@@ -318,12 +287,15 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         return bluePartialDesc;
     }
 
-    function redProxyApplyTrap(blueTarget: BlueFunction, redThisArg: RedValue, redArgArray: RedValue[]): RedValue {
+    // invoking traps
+
+    function redProxyApplyTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, redThisArg: RedValue, redArgArray: RedValue[]): RedValue {
+        const { target: blueTarget } = this;
         let blue;
         try {
             const blueThisArg = blueEnv.getBlueValue(redThisArg);
             const blueArgArray = getStaticBlueArray(redArgArray);
-            blue = blueApplyHook(blueTarget, blueThisArg, blueArgArray);
+            blue = blueApplyHook(blueTarget as BlueFunction, blueThisArg, blueArgArray);
         } catch (e) {
             // This error occurred when the sandbox attempts to call a
             // function from the blue realm. By throwing a new red error,
@@ -346,7 +318,8 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         return getRedValue(blue);
     }
 
-    function redProxyConstructTrap(BlueCtor: BlueConstructor, redArgArray: RedValue[], redNewTarget: RedObject): RedObject {
+    function redProxyConstructTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, redArgArray: RedValue[], redNewTarget: RedObject): RedObject {
+        const { target: BlueCtor } = this;
         if (isUndefined(redNewTarget)) {
             throw TypeError();
         }
@@ -354,7 +327,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         try {
             const blueNewTarget = blueEnv.getBlueValue(redNewTarget);
             const blueArgArray = getStaticBlueArray(redArgArray);
-            blue = blueConstructHook(BlueCtor, blueArgArray, blueNewTarget);
+            blue = blueConstructHook(BlueCtor as BlueConstructor, blueArgArray, blueNewTarget);
         } catch (e) {
             // This error occurred when the sandbox attempts to new a
             // constructor from the blue realm. By throwing a new red error,
@@ -377,223 +350,315 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         return getRedValue(blue);
     }
 
-    /**
-     * RedStaticProxyHandler class is used for any object or function coming from
-     * the blue realm. It implements a proxy handler that takes a snapshot
-     * of the object or function, and preserve them by preventing any mutation
-     * or operation that can cause a side-effect on the original target.
-     */
-    class RedStaticProxyHandler implements ProxyHandler<RedProxyTarget> {
-        // original target for the proxy
-        private readonly target: RedProxyTarget;
-        // metadata about the shape of the target
-        private readonly meta: TargetMeta;
-    
-        constructor(blue: RedProxyTarget, meta: TargetMeta) {
-            this.target = blue;
-            this.meta = meta;
+    // reading traps
+
+    function redProxyDynamicGetTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey, receiver: RedObject): RedValue {
+        /**
+         * If the target has a non-configurable own data descriptor that was observed by the red side,
+         * and therefore installed in the shadowTarget, we might get into a situation where a writable,
+         * non-configurable value in the target is out of sync with the shadowTarget's value for the same
+         * key. This is fine because this does not violate the object invariants, and even though they
+         * are out of sync, the original descriptor can only change to something that is compatible with
+         * what was installed in shadowTarget, and in order to observe that, the getOwnPropertyDescriptor
+         * trap must be used, which will take care of synchronizing them again.
+         */
+        const { target } = this;
+        const blueDescriptor = getOwnPropertyDescriptor(target, key);
+        if (isUndefined(blueDescriptor)) {
+            // looking in the red proto chain in case the red proto chain has being mutated
+            const redProto = getRedValue(getPrototypeOf(target));
+            return ReflectGet(redProto, key, receiver);
         }
-        // initialization used to avoid the initialization cost
-        // of an object graph, we want to do it when the
-        // first interaction happens.
-        private initialize(shadowTarget: RedShadowTarget) {
-            const { meta } = this;
-            const { proto: blueProto } = meta;
-            // once the initialization is executed once... the rest is just noop 
-            defineProperty(this, 'initialize', { value: noop });
-            // adjusting the proto chain of the shadowTarget (recursively)
-            const redProto = getRedValue(blueProto);
-            setPrototypeOf(shadowTarget, redProto);
-            // defining own descriptors
-            copyRedOwnDescriptors(shadowTarget, meta.descriptors);
-            // preserving the semantics of the object
-            if (meta.isFrozen) {
-                freeze(shadowTarget);
-            } else if (meta.isSealed) {
-                seal(shadowTarget);
-            } else if (!meta.isExtensible) {
-                preventExtensions(shadowTarget);
-            }
-            // future optimization: hoping that proxies with frozen handlers can be faster
-            freeze(this);
+        if (hasOwnPropertyCall(blueDescriptor, 'get')) {
+            return apply(getRedValue(blueDescriptor.get), receiver, []);
         }
-    
-        get(shadowTarget: RedShadowTarget, key: PropertyKey, receiver: RedObject): RedValue {
-            this.initialize(shadowTarget);
-            return ReflectGet(shadowTarget, key, receiver);
-        }
-        set(shadowTarget: RedShadowTarget, key: PropertyKey, value: RedValue, receiver: RedObject): boolean {
-            this.initialize(shadowTarget);
-            return ReflectSet(shadowTarget, key, value, receiver);
-        }
-        deleteProperty(shadowTarget: RedShadowTarget, key: PropertyKey): boolean {
-            this.initialize(shadowTarget);
-            return deleteProperty(shadowTarget, key);
-        }
-        apply(shadowTarget: RedShadowTarget, redThisArg: RedValue, redArgArray: RedValue[]): RedValue {
-            const { target: blueTarget } = this;
-            this.initialize(shadowTarget);
-            return redProxyApplyTrap(blueTarget as BlueFunction, redThisArg, redArgArray);
-        }
-        construct(shadowTarget: RedShadowTarget, redArgArray: RedValue[], redNewTarget: RedObject): RedObject {
-            const { target: BlueCtor } = this;
-            this.initialize(shadowTarget);
-            return redProxyConstructTrap(BlueCtor as BlueConstructor, redArgArray, redNewTarget);
-        }
-        has(shadowTarget: RedShadowTarget, key: PropertyKey): boolean {
-            this.initialize(shadowTarget);
-            return key in shadowTarget;
-        }
-        ownKeys(shadowTarget: RedShadowTarget): PropertyKey[] {
-            this.initialize(shadowTarget);
-            return ownKeys(shadowTarget);
-        }
-        isExtensible(shadowTarget: RedShadowTarget): boolean {
-            this.initialize(shadowTarget);
-            // No DOM API is non-extensible, but in the sandbox, the author
-            // might want to make them non-extensible
-            return isExtensible(shadowTarget);
-        }
-        getOwnPropertyDescriptor(shadowTarget: RedShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
-            this.initialize(shadowTarget);
-            return getOwnPropertyDescriptor(shadowTarget, key);
-        }
-        getPrototypeOf(shadowTarget: RedShadowTarget): RedValue {
-            this.initialize(shadowTarget);
-            // nothing to be done here since the shadowTarget must have the right proto chain
-            return getPrototypeOf(shadowTarget);
-        }
-        setPrototypeOf(shadowTarget: RedShadowTarget, prototype: RedValue): boolean {
-            this.initialize(shadowTarget);
-            // this operation can only affect the env object graph
-            return setPrototypeOf(shadowTarget, prototype);
-        }
-        preventExtensions(shadowTarget: RedShadowTarget): boolean {
-            this.initialize(shadowTarget);
-            // this operation can only affect the env object graph
-            return preventExtensions(shadowTarget);
-        }
-        defineProperty(shadowTarget: RedShadowTarget, key: PropertyKey, redPartialDesc: PropertyDescriptor): boolean {
-            this.initialize(shadowTarget);
-            // this operation can only affect the env object graph
-            // intentionally using Object.defineProperty instead of Reflect.defineProperty
-            // to throw for existing non-configurable descriptors.
-            ObjectDefineProperty(shadowTarget, key, redPartialDesc);
-            return true;
-        }
+        // if it is not an accessor property, is either a setter only accessor
+        // or a data property, in which case we could return undefined or the red value
+        return getRedValue(blueDescriptor.value);
     }
-    setPrototypeOf(RedStaticProxyHandler.prototype, null);
-    // future optimization: hoping that proxies with frozen handlers can be faster
-    freeze(RedStaticProxyHandler.prototype);
+
+    function redProxyStaticGetTrap(shadowTarget: RedShadowTarget, key: PropertyKey, receiver: RedObject): RedValue {
+        return ReflectGet(shadowTarget, key, receiver);
+    }
 
     /**
-     * RedDynamicProxyHandler class is used for any object or function coming from
-     * the blue realm that contains the magical symbol to force the proxy to be dynamic.
-     * It implements a proxy handler that delegates all operations to the original target.
+     * This trap cannot just use `Reflect.has` or the `in` operator directly because
+     * the red object graph might have mutations that are only visible on the red side,
+     * which means looking into `target` directly is not viable. Instead, we need to
+     * implement a more crafty solution that looks into target's own properties, or
+     * in the red proto chain when needed.
      */
-    class RedDynamicProxyHandler implements ProxyHandler<RedProxyTarget> {
+    function redProxyDynamicHasTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey): boolean {
+        const { target } = this;
+        if (hasOwnPropertyCall(target, key)) {
+            return true;
+        }
+        // looking in the red proto chain in case the red proto chain has being mutated
+        const redProto = getRedValue(getPrototypeOf(target));
+        return ReflectHas(redProto, key);
+    }
+
+    function redProxyStaticHasTrap(shadowTarget: RedShadowTarget, key: PropertyKey): boolean {
+        return key in shadowTarget;
+    }
+
+    function redProxyDynamicOwnKeysTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget): PropertyKey[] {
+        return ownKeys(this.target);
+    }
+
+    function redProxyStaticOwnKeysTrap(shadowTarget: RedShadowTarget): PropertyKey[] {
+        return ownKeys(shadowTarget);
+    }
+
+    function redProxyDynamicIsExtensibleTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget): boolean {
+        // optimization to avoid attempting to lock down the shadowTarget multiple times
+        if (!isExtensible(shadowTarget)) {
+            return false; // was already locked down
+        }
+        const { target } = this;
+        if (!isExtensible(target)) {
+            lockShadowTarget(shadowTarget, target);
+            return false;
+        }
+        return true;
+    }
+
+    function redProxyStaticIsExtensibleTrap(shadowTarget: RedShadowTarget): boolean {
+        // No DOM API is non-extensible, but in the sandbox, the author
+        // might want to make them non-extensible
+        return isExtensible(shadowTarget);
+    }
+
+    function redProxyDynamicGetOwnPropertyDescriptorTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
+        const { target } = this;
+        const blueDesc = getOwnPropertyDescriptor(target, key);
+        if (isUndefined(blueDesc)) {
+            return blueDesc;
+        }
+        if (blueDesc.configurable === false) {
+            // updating the descriptor to non-configurable on the shadow
+            copyBlueDescriptorIntoShadowTarget(shadowTarget, target, key);
+        }
+        return getRedDescriptor(blueDesc);
+    }
+
+    function redProxyStaticGetOwnPropertyDescriptorTrap(shadowTarget: RedShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
+        return getOwnPropertyDescriptor(shadowTarget, key);
+    }
+
+    function redProxyDynamicGetPrototypeOfTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget): RedValue {
+        return getRedValue(getPrototypeOf(this.target));
+    }
+
+    function redProxyStaticGetPrototypeOfTrap(shadowTarget: RedShadowTarget): RedValue {
+        // nothing to be done here since the shadowTarget must have the right proto chain
+        return getPrototypeOf(shadowTarget);
+    }
+
+    // writing traps
+
+    function redProxyDynamicSetPrototypeOfTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, prototype: RedValue): boolean {
+        return setPrototypeOf(this.target, blueEnv.getBlueValue(prototype));
+    }
+
+    function redProxyStaticSetPrototypeOfTrap(shadowTarget: RedShadowTarget, prototype: RedValue): boolean {
+        // this operation can only affect the env object graph
+        return setPrototypeOf(shadowTarget, prototype);
+    }
+
+    function redProxyDynamicSetTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey, value: RedValue, receiver: RedObject): boolean {
+        const { target } = this;
+        const blueDescriptor = getOwnPropertyDescriptor(target, key);
+        if (isUndefined(blueDescriptor)) {
+            // looking in the red proto chain in case the red proto chain has being mutated
+            const redProto = getRedValue(getPrototypeOf(target));
+            return ReflectSet(redProto, key, value, receiver);
+        }
+        if (hasOwnPropertyCall(blueDescriptor, 'set')) {
+            apply(getRedValue(blueDescriptor.set), receiver, [value]);
+            return true; // because we don't know if the setter actually sets the value, we assume it does it
+        }
+        // if it is not an accessor property, is either a getter only accessor
+        // or a data property, in which case we use Reflect.set to set the value,
+        // and no receiver is needed since it will simply set the data property or nothing
+        return ReflectSet(target, key, blueEnv.getBlueValue(value));
+    }
+
+    function redProxyStaticSetTrap(shadowTarget: RedShadowTarget, key: PropertyKey, value: RedValue, receiver: RedObject): boolean {
+        return ReflectSet(shadowTarget, key, value, receiver);
+    }
+
+    function redProxyDynamicDeletePropertyTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey): boolean {
+        return deleteProperty(this.target, key);
+    }
+
+    function redProxyStaticDeletePropertyTrap(shadowTarget: RedShadowTarget, key: PropertyKey): boolean {
+        return deleteProperty(shadowTarget, key);
+    }
+
+    function redProxyDynamicPreventExtensionsTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget): boolean {
+        const { target } = this;
+        if (isExtensible(shadowTarget)) {
+            if (!preventExtensions(target)) {
+                // if the target is a proxy manually created in the sandbox, it might reject
+                // the preventExtension call, in which case we should not attempt to lock down
+                // the shadow target.
+                if (!isExtensible(target)) {
+                    lockShadowTarget(shadowTarget, target);
+                }
+                return false;
+            }
+            lockShadowTarget(shadowTarget, target);
+        }
+        return true;
+    }
+
+    function redProxyStaticPreventExtensionsTrap(shadowTarget: RedShadowTarget): boolean {
+        // this operation can only affect the env object graph
+        return preventExtensions(shadowTarget);
+    }
+
+    function redProxyDynamicDefinePropertyTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey, redPartialDesc: PropertyDescriptor): boolean {
+        const { target } = this;
+        const blueDesc = getBluePartialDescriptor(redPartialDesc);
+        if (defineProperty(target, key, blueDesc)) {
+            // intentionally testing against true since it could be undefined as well
+            if (blueDesc.configurable === false) {
+                copyBlueDescriptorIntoShadowTarget(shadowTarget, target, key);
+            }
+        }
+        return true;
+    }
+
+    function redProxyStaticDefinePropertyTrap(shadowTarget: RedShadowTarget, key: PropertyKey, redPartialDesc: PropertyDescriptor): boolean {
+        // this operation can only affect the env object graph
+        // intentionally using Object.defineProperty instead of Reflect.defineProperty
+        // to throw for existing non-configurable descriptors.
+        ObjectDefineProperty(shadowTarget, key, redPartialDesc);
+        return true;
+    }
+
+    // pending traps
+
+    function redProxyPendingSetPrototypeOfTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, prototype: RedValue): boolean {
+        makeRedProxyUnambiguous(this, shadowTarget);
+        return this.setPrototypeOf(shadowTarget, prototype);
+    }
+
+    function redProxyPendingSetTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey, value: RedValue, receiver: RedObject): boolean {
+        makeRedProxyUnambiguous(this, shadowTarget);
+        return this.set(shadowTarget, key, value, receiver);
+    }
+
+    function redProxyPendingDeletePropertyTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey): boolean {
+        makeRedProxyUnambiguous(this, shadowTarget);
+        return this.deleteProperty(shadowTarget, key);
+    }
+
+    function redProxyPendingPreventExtensionsTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget): boolean {
+        makeRedProxyUnambiguous(this, shadowTarget);
+        return this.preventExtensions(shadowTarget);
+    }
+
+    function redProxyPendingDefinePropertyTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, key: PropertyKey, redPartialDesc: PropertyDescriptor): boolean {
+        makeRedProxyUnambiguous(this, shadowTarget);
+        return this.defineProperty(shadowTarget, key, redPartialDesc);
+    }
+
+    function makeRedProxyDynamic(proxyHandler: RedProxyHandler, shadowTarget: RedShadowTarget) {
+        // replacing pending traps with dynamic traps that can work with the target
+        // without taking snapshots.
+        proxyHandler.set = redProxyDynamicSetTrap;
+        proxyHandler.deleteProperty = redProxyDynamicDeletePropertyTrap;
+        proxyHandler.setPrototypeOf = redProxyDynamicSetPrototypeOfTrap;
+        proxyHandler.preventExtensions = redProxyDynamicPreventExtensionsTrap;
+        proxyHandler.defineProperty = redProxyDynamicDefinePropertyTrap;
+    }
+
+    function makeRedProxyStatic(proxyHandler: RedProxyHandler, shadowTarget: RedShadowTarget) {
+        const meta = getTargetMeta(proxyHandler.target);
+        const { proto: blueProto, isBroken } = meta;
+        if (isBroken) {
+            // the target is a revoked proxy, in which case we revoke
+            // this proxy as well.
+            proxyHandler.revoke();
+        }
+        // adjusting the proto chain of the shadowTarget
+        const redProto = getRedValue(blueProto);
+        setPrototypeOf(shadowTarget, redProto);
+        // defining own descriptors
+        copyRedOwnDescriptors(shadowTarget, meta.descriptors);
+        // preserving the semantics of the object
+        if (meta.isFrozen) {
+            freeze(shadowTarget);
+        } else if (meta.isSealed) {
+            seal(shadowTarget);
+        } else if (!meta.isExtensible) {
+            preventExtensions(shadowTarget);
+        }
+        // replacing traps with static traps that can work with the shadow target
+        // after the target's snapshot was taken.
+        proxyHandler.get = redProxyStaticGetTrap;
+        proxyHandler.set = redProxyStaticSetTrap;
+        proxyHandler.deleteProperty = redProxyStaticDeletePropertyTrap;
+        proxyHandler.has = redProxyStaticHasTrap;
+        proxyHandler.ownKeys = redProxyStaticOwnKeysTrap;
+        proxyHandler.isExtensible = redProxyStaticIsExtensibleTrap;
+        proxyHandler.getOwnPropertyDescriptor = redProxyStaticGetOwnPropertyDescriptorTrap;
+        proxyHandler.getPrototypeOf = redProxyStaticGetPrototypeOfTrap;
+        proxyHandler.setPrototypeOf = redProxyStaticSetPrototypeOfTrap;
+        proxyHandler.preventExtensions = redProxyStaticPreventExtensionsTrap;
+        proxyHandler.defineProperty = redProxyStaticDefinePropertyTrap;
+    }
+
+    function makeRedProxyUnambiguous(proxyHandler: RedProxyHandler, shadowTarget: RedShadowTarget) {
+        if (isMarkAsDynamic(proxyHandler.target)) {
+            // when the target has the a descriptor for the magic symbol, use the Dynamic traps
+            makeRedProxyDynamic(proxyHandler, shadowTarget);
+        } else {
+            makeRedProxyStatic(proxyHandler, shadowTarget);
+        }
+        // future optimization: hoping that proxies with frozen handlers can be faster
+        freeze(proxyHandler);
+    }
+
+    /**
+     * RedProxyHandler class is used for any object, array or function coming from
+     * the blue realm. The semantics of this proxy handler are the following:
+     *  - the proxy is live (dynamic) after creation
+     *  = once the first mutation trap is called, the handler will be make unambiguous
+     *  - if the target has the magical symbol the proxy will remain as dynamic forever.
+     *  = otherwise proxy will become static by taking a snapshot of the target
+     */
+    class RedProxyHandler implements ProxyHandler<RedProxyTarget>, ProxyHandler<RedShadowTarget> {
         // original target for the proxy
-        private readonly target: RedProxyTarget;
+        readonly target: RedProxyTarget;
+
+        apply = redProxyApplyTrap;
+        construct = redProxyConstructTrap;
+
+        get = redProxyDynamicGetTrap;
+        has = redProxyDynamicHasTrap;
+        ownKeys = redProxyDynamicOwnKeysTrap;
+        isExtensible = redProxyDynamicIsExtensibleTrap;
+        getOwnPropertyDescriptor = redProxyDynamicGetOwnPropertyDescriptorTrap;
+        getPrototypeOf = redProxyDynamicGetPrototypeOfTrap;
+
+        setPrototypeOf = redProxyPendingSetPrototypeOfTrap;
+        set = redProxyPendingSetTrap;
+        deleteProperty = redProxyPendingDeletePropertyTrap;
+        preventExtensions = redProxyPendingPreventExtensionsTrap;
+        defineProperty = redProxyPendingDefinePropertyTrap;
+
+        // revoke is meant to be set right after construction, but
+        // typescript is forcing the initialization :(
+        revoke: () => void = noop;
 
         constructor(blue: RedProxyTarget) {
             this.target = blue;
-            // future optimization: hoping that proxies with frozen handlers can be faster
-            freeze(this);
-        }
-
-        get(shadowTarget: RedShadowTarget, key: PropertyKey, receiver: RedObject): RedValue {
-            /**
-             * If the target has a non-configurable own data descriptor that was observed by the red side,
-             * and therefore installed in the shadowTarget, we might get into a situation where a writable,
-             * non-configurable value in the target is out of sync with the shadowTarget's value for the same
-             * key. This is fine because this does not violate the object invariants, and even though they
-             * are out of sync, the original descriptor can only change to something that is compatible with
-             * what was installed in shadowTarget, and in order to observe that, the getOwnPropertyDescriptor
-             * trap must be used, which will take care of synchronizing them again.
-             */
-            return getRedValue(ReflectGet(this.target, key, blueEnv.getBlueValue(receiver)));
-        }
-        set(shadowTarget: RedShadowTarget, key: PropertyKey, value: RedValue, receiver: RedObject): boolean {
-            return ReflectSet(this.target, key, blueEnv.getBlueValue(value), blueEnv.getBlueValue(receiver));
-        }
-        deleteProperty(shadowTarget: RedShadowTarget, key: PropertyKey): boolean {
-            return deleteProperty(this.target, key);
-        }
-        apply(shadowTarget: RedShadowTarget, redThisArg: RedValue, redArgArray: RedValue[]): RedValue {
-            const { target: blueTarget } = this;
-            return redProxyApplyTrap(blueTarget as BlueFunction, redThisArg, redArgArray);
-        }
-        construct(shadowTarget: RedShadowTarget, redArgArray: RedValue[], redNewTarget: RedObject): RedObject {
-            const { target: BlueCtor } = this;
-            return redProxyConstructTrap(BlueCtor as BlueConstructor, redArgArray, redNewTarget);
-        }
-        has(shadowTarget: RedShadowTarget, key: PropertyKey): boolean {
-            return key in this.target;
-        }
-        ownKeys(shadowTarget: RedShadowTarget): PropertyKey[] {
-            return ownKeys(this.target);
-        }
-        isExtensible(shadowTarget: RedShadowTarget): boolean {
-            // optimization to avoid attempting to lock down the shadowTarget multiple times
-            if (!isExtensible(shadowTarget)) {
-                return false; // was already locked down
-            }
-            const { target } = this;
-            if (!isExtensible(target)) {
-                lockShadowTarget(shadowTarget, target);
-                return false;
-            }
-            return true;
-        }
-        getOwnPropertyDescriptor(shadowTarget: RedShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
-            const { target } = this;
-            const blueDesc = getOwnPropertyDescriptor(target, key);
-            if (isUndefined(blueDesc)) {
-                return blueDesc;
-            }
-            if (blueDesc.configurable === false) {
-                // updating the descriptor to non-configurable on the shadow
-                copyBlueDescriptorIntoShadowTarget(shadowTarget, target, key);
-            }
-            return getRedDescriptor(blueDesc);
-        }
-        getPrototypeOf(shadowTarget: RedShadowTarget): RedValue {
-            return getRedValue(getPrototypeOf(this.target));
-        }
-        setPrototypeOf(shadowTarget: RedShadowTarget, prototype: RedValue): boolean {
-            return setPrototypeOf(this.target, blueEnv.getBlueValue(prototype));
-        }
-        preventExtensions(shadowTarget: RedShadowTarget): boolean {
-            const { target } = this;
-            if (isExtensible(shadowTarget)) {
-                if (!preventExtensions(target)) {
-                    // if the target is a proxy manually created in the sandbox, it might reject
-                    // the preventExtension call, in which case we should not attempt to lock down
-                    // the shadow target.
-                    if (!isExtensible(target)) {
-                        lockShadowTarget(shadowTarget, target);
-                    }
-                    return false;
-                }
-                lockShadowTarget(shadowTarget, target);
-            }
-            return true;
-        }
-        defineProperty(shadowTarget: RedShadowTarget, key: PropertyKey, redPartialDesc: PropertyDescriptor): boolean {
-            const { target } = this;
-            const blueDesc = getBluePartialDescriptor(redPartialDesc);
-            if (defineProperty(target, key, blueDesc)) {
-                // intentionally testing against true since it could be undefined as well
-                if (blueDesc.configurable === false) {
-                    copyBlueDescriptorIntoShadowTarget(shadowTarget, target, key);
-                }
-            }
-            return true;
         }
     }
-    setPrototypeOf(RedDynamicProxyHandler.prototype, null);
-    // future optimization: hoping that proxies with frozen handlers can be faster
-    freeze(RedDynamicProxyHandler.prototype);
+    setPrototypeOf(RedProxyHandler.prototype, null);
 
     function createRedShadowTarget(blue: RedProxyTarget): RedShadowTarget {
         let shadowTarget;
@@ -620,33 +685,13 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         return shadowTarget;
     }
 
-    function getRevokedRedProxy(blue: RedProxyTarget): RedProxy {
-        const shadowTarget = createRedShadowTarget(blue);
-        const { proxy, revoke } = ProxyRevocable(shadowTarget, {});
-        revoke();
-        return proxy;
-    }
-
-    function getStaticRedProxy(blue: RedProxyTarget, meta: TargetMeta): RedProxy {
-        const shadowTarget = createRedShadowTarget(blue);
-        const proxyHandler = new RedStaticProxyHandler(blue, meta);
-        return ProxyCreate(shadowTarget, proxyHandler);
-    }
-
-    function getDynamicRedProxy(blue: RedProxyTarget) {
-        const shadowTarget = createRedShadowTarget(blue);
-        const proxyHandler = new RedDynamicProxyHandler(blue);
-        return ProxyCreate(shadowTarget, proxyHandler);
-    }
-
-    function createStaticRedProxy(blueOriginalValue: RedProxyTarget): RedProxy {
-        const blueOriginalOrDistortedValue = getDistortedValue(blueOriginalValue);
-        const meta = getTargetMeta(blueOriginalOrDistortedValue);
-        const proxy = meta.isBroken ?
-            getRevokedRedProxy(blueOriginalOrDistortedValue) :
-            getStaticRedProxy(blueOriginalOrDistortedValue, meta);
+    function createRedProxy(blueOriginalOrDistortedValue: RedProxyTarget): RedProxy {
+        const shadowTarget = createRedShadowTarget(blueOriginalOrDistortedValue);
+        const proxyHandler = new RedProxyHandler(blueOriginalOrDistortedValue);
+        const { proxy, revoke } = ProxyRevocable(shadowTarget, proxyHandler);
+        proxyHandler.revoke = revoke;
         try {
-            // intentionally storing the original blue object, this way, if a distortion
+            // intentionally storing the distorted blue object, this way, if a distortion
             // exists, and the sandbox passed back its reference to blue, it gets mapped
             // to the distortion rather than the original. This protects against tricking
             // the blue side to use the original value (unwrapping the provided proxy ref)
@@ -659,26 +704,12 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
             // the blue realm.
             throw ErrorCreate('Internal Error');
         }
-        return proxy;
-    }
-
-    // when the target has the a descriptor for the magic symbol, it will use the Dynamic Handler
-    function createDynamicRedProxy(blueOriginalValue: RedProxyTarget): RedProxy {
-        const blueOriginalOrDistortedValue = getDistortedValue(blueOriginalValue);
-        const proxy = getDynamicRedProxy(blueOriginalOrDistortedValue);
         try {
-            // intentionally storing the original blue object, this way, if a distortion
-            // exists, and the sandbox passed back its reference to blue, it gets mapped
-            // to the distortion rather than the original. This protects against tricking
-            // the blue side to use the original value (unwrapping the provided proxy ref)
-            // while the blue side will mistakenly evaluate the original function.
-            blueEnv.setRefMapEntries(proxy, blueOriginalOrDistortedValue);
-        } catch (e) {
-            // This is a very edge case, it could happen if someone is very
-            // crafty, but basically can cause an overflow when invoking the
-            // setRefMapEntries() method, which will report an error from
-            // the blue realm.
-            throw ErrorCreate('Internal Error');
+            isArrayOrNotOrThrowForRevoked(blueOriginalOrDistortedValue);
+        } catch {
+            // detecting revoked targets, it can also be detected later on
+            // during mutations, in which case we will also revoke
+            revoke();
         }
         return proxy;
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -151,6 +151,7 @@ export const ESGlobalKeys = SetCreate([
 // These are foundational things that should never be wrapped but are equivalent
 // TODO: revisit this list.
 export const ReflectiveIntrinsicObjectNames = [
+    'Array',
     'Object',
     'Function',
     'URIError',

--- a/test/membrane/life-red-proxies.spec.js
+++ b/test/membrane/life-red-proxies.spec.js
@@ -1,0 +1,67 @@
+import createSecureEnvironment from '../../lib/browser-realm.js';
+
+const LockerLiveValueMarkerSymbol = Symbol.for('@@lockerLiveValue');
+
+const o = {
+    x: 'uno'
+};
+Object.defineProperty(o, LockerLiveValueMarkerSymbol, {});
+
+const endowments = {
+    o,
+    expect,
+};
+const evalScript = createSecureEnvironment(undefined, endowments);
+
+describe('A Live Red Proxy', () => {
+    it('should surface new expandos from blue realm', function() {
+        // expect.assertions(2);
+        o.x = 'uno';
+        o.y = 'dos';
+        evalScript(`
+            expect(o.x).toBe('uno');
+            expect(o.y).toBe('dos');
+        `);
+    });
+    it('should allow mutation from blue realm', function() {
+        // expect.assertions(4);
+        o.x = 'tres';
+        o.y = 'cuatro';
+        evalScript(`
+            expect(o.x).toBe('tres');
+            expect(o.y).toBe('cuatro');
+        `);
+        expect(o.x).toBe('tres');
+        expect(o.y).toBe('cuatro');
+    });
+    it('should allow mutation from within the sandbox', function() {
+        // expect.assertions(4);
+        evalScript(`
+            o.x = 'cinco';
+            o.y = 'six';
+            expect(o.x).toBe('cinco');
+            expect(o.y).toBe('six');
+        `);
+        expect(o.x).toBe('cinco');
+        expect(o.y).toBe('six');
+    });
+    it('should allow expandos added form within the sandbox', function() {
+        // expect.assertions(2);
+        evalScript(`
+            o.z = 'seven';
+            expect(o.z).toBe('seven');
+        `);
+        expect(o.z).toBe('seven');
+    });
+    it('should only have effect on own properties', function() {
+        // expect.assertions(3);
+        o.w = { a: 1 };
+        evalScript(`
+            o.z = 'seven';
+            expect(o.w.a).toBe(1);
+            o.w.a = 2;
+            expect(o.w.a).toBe(2);
+        `);
+        expect(o.w.a).toBe(1);
+    });
+});

--- a/test/membrane/object-graph-mutations.spec.js
+++ b/test/membrane/object-graph-mutations.spec.js
@@ -22,7 +22,8 @@ describe('The object graph', () => {
 
             const elm = document.createElement('p');
             document.body.appendChild(elm);
-            
+
+            expect('x' in elm).toBe(true);
             expect(elm.x).toBe(1);
             expect(() => {
                 elm.x = 100;


### PR DESCRIPTION
Most red proxies will use the snapshotting technique to prevent sandboxed code to affect the integrity of the blue realm by mutating those object, but there are certain exceptions to this rule.

This PR introduces a new controlled mechanism that allows developers to mark certain objects as live objects, and in that case, the sandboxed code will have the ability to mutate the descriptors installed on that object. E.g.:

```js
const magicSymbol = Symbol.for('@@lockerLiveValue');
const blueObj = { x: 1 };
Reflect.defineProperty(blueObj, magicSymbol, {});
```

In the example above, if a red realm get access to `blueObj` via a red proxy, that proxy will not do snapshotting, but will support live values, and potential mutations on that object.

This also fixes https://github.com/caridy/secure-javascript-environment/issues/63 by providing a way for keeping some of those objects as live.