### PR TITLE
fix: null proto in red "get" proxy trap

### DIFF
--- a/src/red.ts
+++ b/src/red.ts
@@ -374,6 +374,10 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         if (isUndefined(blueDescriptor)) {
             // looking in the red proto chain in case the red proto chain has being mutated
             const redProto = getRedValue(getPrototypeOf(target));
+            // some objects may have a null prototype so return undefined
+            if (isNull(redProto)) {
+                return undefined;
+            }
             return ReflectGet(redProto, key, receiver);
         }
         if (hasOwnPropertyCall(blueDescriptor, 'get')) {


### PR DESCRIPTION
Some objects that are constructed with `Object.create(null)` will not have a prototype and ReflectGet utility will throw an error. 
This PR addresses this issue.