### PR TITLE
Implement Crossing Membrane Invariant in Blue Handler

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -22,6 +22,7 @@ export const {
     ownKeys,
     preventExtensions: ReflectPreventExtensions,
     deleteProperty,
+    has: ReflectHas,
     get: ReflectGet,
     set: ReflectSet,
 } = Reflect;

--- a/test/membrane/blue-expandos.spec.js
+++ b/test/membrane/blue-expandos.spec.js
@@ -1,0 +1,28 @@
+import createSecureEnvironment from '../../lib/browser-realm.js';
+
+class Base {
+    constructor() {
+        this.statusVariable = 'initial';
+    }
+}
+let FooClazz;
+function saveFoo(arg) {
+    FooClazz = arg;
+}
+
+describe('The blue expandos', () => {
+    it('should never be subject to red side mutations', function() {
+        // expect.assertions(4);
+        const evalScript = createSecureEnvironment(undefined, { Base, saveFoo });
+        evalScript(`
+            function mixin(Clazz) {
+                return class extends Clazz {}
+            }
+            const Foo = mixin(Base);
+            saveFoo(Foo);
+        `);
+        class Test extends FooClazz {}
+        const instance = new Test();
+        expect(instance.statusVariable).toBe('initial');
+    });
+});


### PR DESCRIPTION
This PR implement a new invariant that membrane should never switch sides when get/set/has traps are called because it looses track of the initiator of the interaction, which determines whether or not you can see distortions or mutations from red.

This code is mostly copied from red.ts, where we have already implemented those semantics, it turns out that this was also needed in blue.ts otherwise you might ended up effected by mutations or distortions only visible in the red side because these 3 traps were switching sides by calling Reflect.set/get/has on the red side.

* [x] tests

### Details

This issue was identified by @dejang, and is reproducible by the following code:

```js
import createSecureEnvironment from '../../lib/browser-realm.js';
class Base {
    constructor() {
        this.statusVariable = 'initial';
    }
}
let FooClazz;
function saveFoo(arg) {
    FooClazz = arg;
}
const evalScript = createSecureEnvironment(undefined, { Base, saveFoo });
evalScript(`
    function mixin(Clazz) {
        return class extends Clazz {}
    }
    const Foo = mixin(Base);
    saveFoo(Foo);
`);
it('reading value from Base class', () => {
    class Test extends FooClazz {}
    const instance = new Test();
    expect(instance.statusVariable).toBe('initial'); // fails, it is undefined
});
```

In the example above, the problem is that the `instance` which is a blue object with a proto-chain that is red, then finally blue (Base.prototype), is switching to the red side as soon as the instance `set` trap is called, and from that point on, it remains on the red side forever, and it is subject to red side semantics, which in this case will take snapshot of the red proxy around `instance`.

With the change in this PR, it will not longer get to the red side, instead, it walks the proto on the blue side, until it sets the value as an expando on the blue instance from the blue side, no snapshot is taken because the initiator of the call is the blue side.