### PR TITLE
fix: guarding against null prototypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "ttsc -w & http-server",
     "test": "jest --runInBand --no-cache --config ./jest.config.js",
     "publish": "npm publish --access public",
-    "debug": "karma start karma.config.js --browsers ChromeHeadless",
+    "debug": "karma start karma.config.js --browsers Chrome",
     "karma": "karma start karma.config.js --single-run --browsers ChromeHeadless,FirefoxHeadless"
   },
   "files": [

--- a/src/blue.ts
+++ b/src/blue.ts
@@ -236,7 +236,7 @@ export function blueProxyFactory(env: MembraneBroker) {
                 // looking in the blue proto chain to avoid switching sides
                 const blueProto = getBlueValue(ReflectGetPrototypeOf(target));
                 if (isNull(blueProto)) {
-                    return;
+                    return undefined;
                 }
                 return ReflectGet(blueProto, key, receiver);
             }

--- a/src/blue.ts
+++ b/src/blue.ts
@@ -15,6 +15,7 @@ import {
     ReflectSet,
     ReflectHas,
     map,
+    isNull,
     isNullOrUndefined,
     unconstruct,
     ownKeys,
@@ -181,7 +182,7 @@ export function blueProxyFactory(env: MembraneBroker) {
             }
             return env.getBlueValue(red);
         }
-        construct(shadowTarget: BlueShadowTarget, blueArgArray: BlueValue[], blueNewTarget: BlueObject): BlueObject {
+        construct(shadowTarget: BlueShadowTarget, blueArgArray: BlueValue[], blueNewTarget: BlueObject): BlueValue {
             const { target: RedCtor } = this;
             if (isUndefined(blueNewTarget)) {
                 throw TypeError();
@@ -234,13 +235,16 @@ export function blueProxyFactory(env: MembraneBroker) {
             if (isUndefined(redDescriptor)) {
                 // looking in the blue proto chain to avoid switching sides
                 const blueProto = getBlueValue(ReflectGetPrototypeOf(target));
+                if (isNull(blueProto)) {
+                    return;
+                }
                 return ReflectGet(blueProto, key, receiver);
             }
             if (hasOwnProperty(redDescriptor, 'get')) {
                 // Knowing that it is an own getter, we can't still not use Reflect.get
                 // because there might be a distortion for such getter, and from the blue
                 // side, we should not be subject to those distortions.
-                return apply(getBlueValue(redDescriptor.get), receiver, emptyArray);
+                return apply(getBlueValue(redDescriptor.get!), receiver, emptyArray);
             }
             // if it is not an accessor property, is either a setter only accessor
             // or a data property, in which case we could return undefined or the blue value
@@ -259,13 +263,14 @@ export function blueProxyFactory(env: MembraneBroker) {
             if (isUndefined(redDescriptor)) {
                 // looking in the blue proto chain to avoid switching sides
                 const blueProto = getBlueValue(ReflectGetPrototypeOf(target));
-                return ReflectSet(blueProto, key, value, receiver);
-            }
-            if (hasOwnProperty(redDescriptor, 'set')) {
+                if (!isNull(blueProto)) {
+                    return ReflectSet(blueProto, key, value, receiver);
+                }
+            } else if (hasOwnProperty(redDescriptor, 'set')) {
                 // even though the setter function exists, we can't use Reflect.set because there might be
                 // a distortion for that setter function, and from the blue side, we should not be subject
                 // to those distortions.
-                apply(getBlueValue(redDescriptor.set), receiver, [value]);
+                apply(getBlueValue(redDescriptor.set!), receiver, [value]);
                 return true; // if there is a callable setter, it either throw or we can assume the value was set
             }
             // if it is not an accessor property, is either a getter only accessor
@@ -287,7 +292,7 @@ export function blueProxyFactory(env: MembraneBroker) {
             }
             // looking in the blue proto chain to avoid switching sides
             const blueProto = getBlueValue(ReflectGetPrototypeOf(target));
-            return ReflectHas(blueProto, key);
+            return !isNull(blueProto) && ReflectHas(blueProto, key);
         }
         ownKeys(shadowTarget: BlueShadowTarget): PropertyKey[] {
             return ownKeys(this.target);
@@ -354,17 +359,17 @@ export function blueProxyFactory(env: MembraneBroker) {
     // future optimization: hoping that proxies with frozen handlers can be faster
     freeze(BlueDynamicProxyHandler.prototype);
 
-    function getBlueValue(red: RedValue): BlueValue {
+    function getBlueValue<T>(red: T): T {
         if (isNullOrUndefined(red)) {
             return red as BlueValue;
         }
         if (typeof red === 'function') {
-            return getBlueFunction(red);
+            return (getBlueFunction((red as unknown) as RedFunction) as unknown) as T;
         } else if (typeof red === 'object') {
             // arrays and objects
             const blue = env.getBlueRef(red);
             if (isUndefined(blue)) {
-                return createBlueProxy(red);
+                return (createBlueProxy((red as unknown) as BlueProxyTarget) as unknown) as T;
             }
             return blue;
         }

--- a/src/red.ts
+++ b/src/red.ts
@@ -377,7 +377,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
             // looking in the red proto chain in case the red proto chain has being mutated
             const redProto = getRedValue(getPrototypeOf(target));
             if (isNull(redProto)) {
-                return;
+                return undefined;
             }
             return ReflectGet(redProto, key, receiver);
         }

--- a/src/red.ts
+++ b/src/red.ts
@@ -23,6 +23,7 @@ import {
     BlueArray,
     TargetMeta,
     MembraneBroker,
+    BlueObject,
 } from './types';
 
 /**
@@ -126,9 +127,9 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         return hasDynamicMark;
     }
 
-    function getRedValue(blue: BlueValue): RedValue {
+    function getRedValue<T>(blue: T): T  {
         if (isNullOrUndefined(blue)) {
-            return blue as RedValue;
+            return blue;
         }
         // NOTE: internationally checking for typeof 'undefined' for the case of
         // `typeof document.all === 'undefined'`, which is an exotic object with
@@ -137,17 +138,18 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         // This check covers that case, but doesn't affect other undefined values
         // because those are covered by the previous condition anyways.
         if (typeof blue === 'undefined') {
+            // @ts-ignore blue at this point is type T because of the previous condition
             return undefined;
         }
         if (typeof blue === 'object' || typeof blue === 'function') {
-            const blueOriginalOrDistortedValue = getDistortedValue(blue);
+            const blueOriginalOrDistortedValue = getDistortedValue((blue as unknown) as BlueFunction | BlueObject | BlueArray);
             const red: RedValue | undefined = WeakMapGet(blueMap, blueOriginalOrDistortedValue);
             if (!isUndefined(red)) {
                 return red;
             }
-            return createRedProxy(blueOriginalOrDistortedValue);
+            return createRedProxy(blueOriginalOrDistortedValue) as unknown as T;
         }
-        return blue as RedValue;
+        return blue;
     }
 
     function getStaticBlueArray(redArray: RedArray): BlueArray {
@@ -318,7 +320,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         return getRedValue(blue);
     }
 
-    function redProxyConstructTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, redArgArray: RedValue[], redNewTarget: RedObject): RedObject {
+    function redProxyConstructTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget, redArgArray: RedValue[], redNewTarget: RedObject): RedValue {
         const { target: BlueCtor } = this;
         if (isUndefined(redNewTarget)) {
             throw TypeError();
@@ -374,13 +376,16 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         if (isUndefined(blueDescriptor)) {
             // looking in the red proto chain in case the red proto chain has being mutated
             const redProto = getRedValue(getPrototypeOf(target));
+            if (isNull(redProto)) {
+                return;
+            }
             return ReflectGet(redProto, key, receiver);
         }
         if (hasOwnPropertyCall(blueDescriptor, 'get')) {
             // Knowing that it is an own getter, we can't still not use Reflect.get
             // because there might be a distortion for such getter, in which case we
             // must get the red getter, and call it.
-            return apply(getRedValue(blueDescriptor.get), receiver, emptyArray);
+            return apply(getRedValue(blueDescriptor.get!), receiver, emptyArray);
         }
         // if it is not an accessor property, is either a setter only accessor
         // or a data property, in which case we could return undefined or the red value
@@ -401,7 +406,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         }
         // looking in the red proto chain in case the red proto chain has being mutated
         const redProto = getRedValue(getPrototypeOf(target));
-        return ReflectHas(redProto, key);
+        return !isNull(redProto) && ReflectHas(redProto, key);
     }
 
     function redProxyDynamicOwnKeysTrap(this: RedProxyHandler, shadowTarget: RedShadowTarget): PropertyKey[] {
@@ -463,7 +468,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
             // even though the setter function exists, we can't use Reflect.set because there might be
             // a distortion for that setter function, in which case we must resolve the red setter
             // and call it instead.
-            apply(getRedValue(blueDescriptor.set), receiver, [value]);
+            apply(getRedValue(blueDescriptor.set!), receiver, [value]);
             return true; // if there is a callable setter, it either throw or we can assume the value was set
         }
         // if it is not an accessor property, is either a getter only accessor

--- a/test/membrane/blue-expandos.spec.js
+++ b/test/membrane/blue-expandos.spec.js
@@ -12,7 +12,7 @@ function saveFoo(arg) {
 
 describe('The blue expandos', () => {
     it('should never be subject to red side mutations', function() {
-        // expect.assertions(4);
+        // expect.assertions(1);
         const evalScript = createSecureEnvironment(undefined, { Base, saveFoo });
         evalScript(`
             function mixin(Clazz) {

--- a/test/membrane/null-protos.spec.js
+++ b/test/membrane/null-protos.spec.js
@@ -1,0 +1,58 @@
+import createSecureEnvironment from '../../lib/browser-realm.js';
+
+const bar = Object.create(null, {
+    x: { value: 1 },
+    z: { value: 5, writable: true }
+});
+let foo;
+function saveFoo(arg) {
+    foo = arg;
+}
+
+describe('null __proto__', () => {
+    it('should work for get trap', function() {
+        // expect.assertions(4);
+        const evalScript = createSecureEnvironment(undefined, { bar, saveFoo, expect });
+        evalScript(`
+            const foo = Object.create(null, {
+                y: { value: 2 }
+            });
+            saveFoo(foo);
+            expect(bar.x).toBe(1);
+            expect(bar.y).toBe(undefined);
+        `);
+        expect(foo.x).toBe(undefined);
+        expect(foo.y).toBe(2);
+    });
+    it('should work for set trap', function() {
+        // expect.assertions(6);
+        const evalScript = createSecureEnvironment(undefined, { bar, saveFoo, expect });
+        evalScript(`
+            const foo = Object.create(null, {
+                x: { value: 2 },
+                y: { value: 3, writable: true }
+            });
+            saveFoo(foo);
+            expect(Reflect.set(bar, 'x', 2)).toBe(false); // non-writable
+            expect(Reflect.set(bar, 'expando', 3)).toBe(true);
+            expect(Reflect.set(bar, 'z', 4)).toBe(true);
+        `);
+        expect(Reflect.set(foo, 'x', 5)).toBe(false); // non-writable
+        expect(Reflect.set(foo, 'expando', 6)).toBe(true);
+        expect(Reflect.set(foo, 'y', 7)).toBe(true);
+    });
+    it('should work for has trap', function() {
+        // expect.assertions(4);
+        const evalScript = createSecureEnvironment(undefined, { bar, saveFoo, expect });
+        evalScript(`
+            const foo = Object.create(null, {
+                y: { value: 2, writable: true }
+            });
+            saveFoo(foo);
+            expect('x' in bar).toBe(true);
+            expect('y' in bar).toBe(false);
+        `);
+        expect('x' in foo).toBe(false);
+        expect('y' in foo).toBe(true);
+    });
+});


### PR DESCRIPTION
there were 6 places were we retrieve the `__proto__`, and we were not protecting against that being `null` in the following lines. This PR takes care of that, plus add some more types protections.

 * [x] tests