### PR TITLE
fix issue with dynamic red and blue proxies that can be now freeze without invariant violations

### DIFF
--- a/src/blue.ts
+++ b/src/blue.ts
@@ -131,10 +131,14 @@ export function blueProxyFactory(env: MembraneBroker) {
     }
 
     function lockShadowTarget(shadowTarget: BlueShadowTarget, originalTarget: BlueProxyTarget) {
+        // copying all own properties into the shadowTarget
         const targetKeys = ownKeys(originalTarget);
         for (let i = 0, len = targetKeys.length; i < len; i += 1) {
             copyRedDescriptorIntoShadowTarget(shadowTarget, originalTarget, targetKeys[i]);
         }
+        // setting up __proto__ of the shadowTarget
+        ReflectSetPrototypeOf(shadowTarget, getBlueValue(ReflectGetPrototypeOf(originalTarget)));
+        // locking down the extensibility of shadowTarget
         ReflectPreventExtensions(shadowTarget);
     }
 

--- a/src/red.ts
+++ b/src/red.ts
@@ -237,10 +237,14 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
     }
 
     function lockShadowTarget(shadowTarget: RedShadowTarget, originalTarget: RedProxyTarget) {
+        // copying all own properties into the shadowTarget
         const targetKeys = ownKeys(originalTarget);
         for (let i = 0, len = targetKeys.length; i < len; i += 1) {
             copyBlueDescriptorIntoShadowTarget(shadowTarget, originalTarget, targetKeys[i]);
         }
+        // setting up __proto__ of the shadowTarget
+        setPrototypeOf(shadowTarget, getRedValue(getPrototypeOf(originalTarget)));
+        // locking down the extensibility of shadowTarget
         preventExtensions(shadowTarget);
     }
 

--- a/test/membrane/invariant.spec.js
+++ b/test/membrane/invariant.spec.js
@@ -1,10 +1,10 @@
 import createSecureEnvironment from '../../lib/browser-realm.js';
 
+// This emulates LWC LightningElement proto chain and freezing mechanism
 class Base {}
 Object.freeze(Base.prototype);
 let FooClazz;
 function saveFoo(arg) {
-    debugger;
     Object.freeze(arg.prototype);
     FooClazz = arg;
 }

--- a/test/membrane/invariant.spec.js
+++ b/test/membrane/invariant.spec.js
@@ -1,0 +1,24 @@
+import createSecureEnvironment from '../../lib/browser-realm.js';
+
+class Base {}
+Object.freeze(Base.prototype);
+let FooClazz;
+function saveFoo(arg) {
+    debugger;
+    Object.freeze(arg.prototype);
+    FooClazz = arg;
+}
+
+const evalScript = createSecureEnvironment(undefined, { Base, saveFoo });
+evalScript(`
+    class Foo extends Base {};
+    saveFoo(Foo);
+`);
+
+describe('js invariants', () => {
+    it('should be prserved for instanceof', () => {
+        class Test extends FooClazz {};
+        Object.freeze(Test.prototype);
+        expect(Test.prototype instanceof Base).toBe(true); 
+    });
+});


### PR DESCRIPTION
When locking down the shadowTarget of a dynamic proxy (both blue and red), we were not adjusting the `__proto__`, causing that any proto chain lookup after setting the object to not extensible to report an invariant violation.