### PR TITLE
chore(membrane): Test for super.value writes

### DIFF
--- a/test/membrane/super.spec.js
+++ b/test/membrane/super.spec.js
@@ -1,0 +1,32 @@
+import createSecureEnvironment from '../../lib/browser-realm.js'
+
+it('super.value reads should return value from current sandbox', () => {
+  let exported
+  const exportValue = (arg) => {
+    exported = arg;
+  }
+
+  const secureEvalOne = createSecureEnvironment(undefined, { exportValue });
+  secureEvalOne(
+    `class Foo { 
+        constructor() { 
+            this.value = "base" ;
+        } 
+    }
+    exportValue(Foo);`,
+  )
+  const Foo = exported;
+
+  const secureEvalTwo = createSecureEnvironment(undefined, { expect, Foo });
+  secureEvalTwo(`
+    class Bar extends Foo {
+        constructor() {
+            super();
+            super.value = 'bar';
+            expect(super.value).toBe('bar');
+        }
+    }
+
+    new Bar();
+  `)
+})


### PR DESCRIPTION
When dealing with a cross-environment situation where one class extends a class from a different environment and writing values using `super` will result in `undefined` on reads.