### PR TITLE
fix: ownKeys trap for classes and strict mode functions

### DIFF
--- a/src/blue.ts
+++ b/src/blue.ts
@@ -63,7 +63,7 @@ function createBlueShadowTarget(target: BlueProxyTarget): BlueShadowTarget {
             shadowTarget = 'prototype' in target ? function () {} : () => {};
         } catch {
             // target is a revoked proxy
-            shadowTarget = () => {};
+            shadowTarget = function () {};
         }
         // This is only really needed for debugging, it helps to identify the proxy by name
         renameFunction(target as (...args: any[]) => any, shadowTarget as (...args: any[]) => any);

--- a/test/membrane/ownKeys.spec.js
+++ b/test/membrane/ownKeys.spec.js
@@ -1,0 +1,31 @@
+import createSecureEnvironment from '../../lib/browser-realm.js';
+
+let exported;
+function exportData(arg) {
+  exported = arg;
+}
+
+const oneScript = `
+    exportData([
+      class Foo {},
+      function() {'use strict'}
+    ]);
+`;
+
+const twoScript = `
+    exportData(imported.map(Reflect.ownKeys));
+`;
+
+it('does not throw ownKeys trap invariant for classes or strict mode functions', () => {
+  const secureEvalOne = createSecureEnvironment(undefined, { exportData });
+  secureEvalOne(oneScript);
+  const secureEvalTwo = createSecureEnvironment(
+    undefined,
+    { exportData, imported: exported }
+  );
+  secureEvalTwo(twoScript);
+  const matcher = jasmine.arrayWithExactContents(['length', 'name', 'prototype']);
+  exported.forEach(ownKeys => {
+    expect(ownKeys).toEqual(matcher);
+  });
+});


### PR DESCRIPTION
This PR addresses #96 and avoids ownKeys trap invariant errors for classes and strict mode functions.