### PR TITLE
chore(types): Adding *to*ReferencesMap types to MembraneBroker interface

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -24,7 +24,6 @@ import { serializedRedEnvSourceText, MarshalHooks } from './red';
 import { blueProxyFactory } from './blue';
 import {
     RedObject,
-    RedFunction,
     BlueFunction,
     BlueObject,
     RedProxyTarget,
@@ -33,9 +32,8 @@ import {
     BlueConstructor,
     MembraneBroker,
     DistortionMap,
-    RedProxy,
-    BlueProxy,
-    BlueProxyTarget,
+    RedToBlueReferencesMap,
+    BlueToRedReferencesMap,
 } from './types';
 
 interface SecureEnvironmentOptions {
@@ -72,9 +70,9 @@ getReflectiveIntrinsics(globalThis);
 
 export class SecureEnvironment implements MembraneBroker {
     // map from red to blue references
-    redMap: WeakMap<RedFunction | RedObject, RedProxyTarget | BlueProxy> = WeakMapCreate();
+    redMap: RedToBlueReferencesMap = WeakMapCreate();
     // map from blue to red references
-    blueMap: WeakMap<BlueFunction | BlueObject, RedProxy | BlueProxyTarget> = WeakMapCreate();
+    blueMap: BlueToRedReferencesMap = WeakMapCreate();
     // blue object distortion map
     distortionMap: DistortionMap;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,11 +33,14 @@ export type BlueProxy = BlueObject | BlueFunction;
 
 export type DistortionMap = WeakMap<RedProxyTarget, RedProxyTarget>;
 
+export type RedToBlueReferencesMap = WeakMap<RedProxy, RedProxyTarget | BlueProxy>;
+export type BlueToRedReferencesMap = WeakMap<BlueProxy, BlueProxyTarget | RedProxy>;
+
 export interface MembraneBroker {
     // map from red to blue references
-    redMap: WeakMap<RedFunction | RedObject, RedProxyTarget | BlueProxy>;
+    redMap: RedToBlueReferencesMap;
     // map from blue to red references
-    blueMap: WeakMap<BlueFunction | BlueObject, RedProxy | BlueProxyTarget>;
+    blueMap: BlueToRedReferencesMap;
     // blue object distortion map
     distortionMap: DistortionMap;
 


### PR DESCRIPTION
Abstracted `RedToBlueReferencesMap` and `BlueToRedReferencesMap` types and used them in `MembraneBroker` interface.