### PR TITLE
fix(x-realm) ensure promises created with Promise resolve

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -116,7 +116,9 @@ export const ESGlobalKeys = SetCreate([
     'Map',
     'Number',
     'Object',
-    'Promise', // Unstable
+    // Allow Blue `Promise` constructor to overwrite the Red one so that promises
+    // created by the `Promise` constructor or APIs like `fetch` will work.
+    //'Promise',
     'Proxy', // Unstable
     'RangeError',
     'ReferenceError',


### PR DESCRIPTION
This PR fixes promise resolving in Firefox/Safari for promises created with `Promise`. It does not address those created with `async await`.