### PR TITLE
fix: add semicolon to 'use strict' directive in serializedRedEnvSourceText

### DIFF
--- a/src/red.ts
+++ b/src/red.ts
@@ -705,4 +705,4 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
 // We cannot have 'use strict' directly in `redEnvFactory()` because bundlers and
 // minifiers may strip the directive. So, we inject 'use strict' after the function
 // is coerced to a string.
-.replace('{', `{'use strict'`);
+.replace('{', `{'use strict';`);


### PR DESCRIPTION
When sent to the client in a minified script (terser), `serializedRedEnvSourceText` value starts with `function(t,e){'use strict'const n=Symbol.for(\"@@lockerLiveValue\"), [...]}` which fails to evaluate with `SyntaxError: unexpected token: keyword 'const'`. 