### PR TITLE
test: throw should be supported in promises

### DIFF
--- a/test/membrane/promises.spec.js
+++ b/test/membrane/promises.spec.js
@@ -33,4 +33,28 @@ describe("Promise", () => {
             });
         `);
     });
+    it("throw should be supported with errors", (done) => {
+        const evalScript = createSecureEnvironment(undefined, { done, expect });
+        evalScript(`
+            const p = new Promise(() => {
+                throw new Error('foo');
+            });
+            p.catch((e) => {
+                expect(e.message).toBe('foo');
+                done();
+            });
+        `);
+    });
+    it("throw should be supported with non-errors", (done) => {
+        const evalScript = createSecureEnvironment(undefined, { done, expect });
+        evalScript(`
+            const p = new Promise(() => {
+                throw { foo: 'bar' };
+            });
+            p.catch((e) => {
+                expect(e).toEqual({ foo: 'bar' });
+                done();
+            });
+        `);
+    });
 });


### PR DESCRIPTION
This PR adds 2 tests, `throw should be supported with errors` pass but `throw should be supported with non-errors` fails. 

It seems like we are assuming that exceptions thrown are `Error` instances or at least will have a `message` field and a constructor? https://github.com/caridy/secure-javascript-environment/blob/481234e1f99ca5c510ad106489ce5c7918b3d0e5/src/blue.ts#L173

Is it a bug or am I doing something wrong? 