### PR TITLE
refactor(membrane): red to blue and vice-versa errors

### DIFF
--- a/src/blue.ts
+++ b/src/blue.ts
@@ -9,7 +9,6 @@ import {
     isUndefined,
     ReflectGetOwnPropertyDescriptor,
     ReflectDefineProperty,
-    ErrorCreate,
     ReflectGetPrototypeOf,
     ReflectGet,
     ReflectSet,
@@ -24,6 +23,7 @@ import {
     deleteProperty,
     hasOwnProperty,
     emptyArray,
+    remapToBlueError,
 } from './shared';
 import {
     BlueProxyTarget,
@@ -169,21 +169,7 @@ export function blueProxyFactory(env: MembraneBroker) {
                 // This error occurred when the blue realm attempts to call a
                 // function from the sandbox. By throwing a new blue error, we eliminates the stack
                 // information from the sandbox as a consequence.
-                let blueError;
-                const { message, constructor } = e;
-                try {
-                    // the error constructor must be a red error since it occur when calling
-                    // a function from the sandbox.
-                    const blueErrorConstructor = env.getBlueValue(constructor);
-                    // the blue constructor must be registered (done during construction of env)
-                    // otherwise we need to fallback to a regular error.
-                    blueError = construct(blueErrorConstructor as BlueFunction, [message]);
-                } catch {
-                    // in case the constructor inference fails
-                    blueError = ErrorCreate(message);
-                }
-                env.setRefMapEntries(e, blueError);
-                throw blueError;
+                throw remapToBlueError(env, e);
             }
             return env.getBlueValue(red);
         }
@@ -201,21 +187,7 @@ export function blueProxyFactory(env: MembraneBroker) {
                 // This error occurred when the blue realm attempts to new a
                 // constructor from the sandbox. By throwing a new blue error, we eliminates the stack
                 // information from the sandbox as a consequence.
-                let blueError;
-                const { message, constructor } = e;
-                try {
-                    // the error constructor must be a red error since it occur when calling
-                    // a function from the sandbox.
-                    const blueErrorConstructor = env.getBlueValue(constructor);
-                    // the blue constructor must be registered (done during construction of env)
-                    // otherwise we need to fallback to a regular error.
-                    blueError = construct(blueErrorConstructor as BlueFunction, [message]);
-                } catch {
-                    // in case the constructor inference fails
-                    blueError = ErrorCreate(message);
-                }
-                env.setRefMapEntries(e, blueError);
-                throw blueError;
+                throw remapToBlueError(env, e);
             }
             return env.getBlueValue(red);
         }

--- a/src/blue.ts
+++ b/src/blue.ts
@@ -23,7 +23,6 @@ import {
     deleteProperty,
     hasOwnProperty,
     emptyArray,
-    remapToBlueError,
 } from './shared';
 import {
     BlueProxyTarget,
@@ -166,10 +165,7 @@ export function blueProxyFactory(env: MembraneBroker) {
             try {
                 red = apply(target as RedFunction, redThisArg, redArgArray);
             } catch (e) {
-                // This error occurred when the blue realm attempts to call a
-                // function from the sandbox. By throwing a new blue error, we eliminates the stack
-                // information from the sandbox as a consequence.
-                throw remapToBlueError(env, e);
+                throw env.getBlueValue(e);
             }
             return env.getBlueValue(red);
         }
@@ -184,10 +180,7 @@ export function blueProxyFactory(env: MembraneBroker) {
             try {
                 red = construct(RedCtor as RedConstructor, redArgArray, redNewTarget);
             } catch (e) {
-                // This error occurred when the blue realm attempts to new a
-                // constructor from the sandbox. By throwing a new blue error, we eliminates the stack
-                // information from the sandbox as a consequence.
-                throw remapToBlueError(env, e);
+                throw env.getBlueValue(e);
             }
             return env.getBlueValue(red);
         }

--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -1,11 +1,9 @@
 import { SecureEnvironment } from "./environment";
-import { RedProxyTarget, BlueFunction } from "./types";
+import { RedProxyTarget } from "./types";
 import {
     ReflectGetPrototypeOf,
     ReflectSetPrototypeOf,
     getOwnPropertyDescriptors,
-    construct,
-    ErrorCreate,
     WeakMapCreate,
     isUndefined,
     ObjectCreate,
@@ -14,6 +12,7 @@ import {
     ownKeys,
     unapply,
     ReflectGetOwnPropertyDescriptor,
+    remapToBlueError,
 } from "./shared";
 
 /**
@@ -241,19 +240,7 @@ export default function createSecureEnvironment(distortionMap?: Map<RedProxyTarg
             // This error occurred when the blue realm attempts to evaluate a
             // sourceText into the sandbox. By throwing a new blue error, which
             // eliminates the stack information from the sandbox as a consequence.
-            let blueError;
-            const { message, constructor } = e;
-            try {
-                const blueErrorConstructor = env.getBlueValue(constructor);
-                // the constructor must be registered (done during construction of env)
-                // otherwise we need to fallback to a regular error.
-                blueError = construct(blueErrorConstructor as BlueFunction, [message]);
-            } catch {
-                // in case the constructor inference fails
-                blueError = ErrorCreate(message);
-            }
-            env.setRefMapEntries(e, blueError);
-            throw blueError;
+            throw remapToBlueError(env, e);
         }
     };
 }

--- a/src/browser-realm.ts
+++ b/src/browser-realm.ts
@@ -12,7 +12,6 @@ import {
     ownKeys,
     unapply,
     ReflectGetOwnPropertyDescriptor,
-    remapToBlueError,
 } from "./shared";
 
 /**
@@ -237,10 +236,7 @@ export default function createSecureEnvironment(distortionMap?: Map<RedProxyTarg
         try {
             redIndirectEval(sourceText);
         } catch (e) {
-            // This error occurred when the blue realm attempts to evaluate a
-            // sourceText into the sandbox. By throwing a new blue error, which
-            // eliminates the stack information from the sandbox as a consequence.
-            throw remapToBlueError(env, e);
+            throw env.getBlueValue(e);
         }
     };
 }

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -1,6 +1,6 @@
 import { SecureEnvironment } from "./environment";
 import { RedProxyTarget } from "./types";
-import { getOwnPropertyDescriptors, remapToBlueError } from "./shared";
+import { getOwnPropertyDescriptors } from "./shared";
 import { runInNewContext } from 'vm';
 
 // note: in a node module, the top-level 'this' is not the global object
@@ -26,10 +26,7 @@ export default function createSecureEnvironment(distortionMap?: Map<RedProxyTarg
         try {
             redIndirectEval(sourceText);
         } catch (e) {
-            // This error occurred when the blue realm attempts to evaluate a
-            // sourceText into the sandbox. By throwing a new blue error, which
-            // eliminates the stack information from the sandbox as a consequence.
-            throw remapToBlueError(env, e);
+            throw env.getBlueValue(e);
         }
     };
 }

--- a/src/node-realm.ts
+++ b/src/node-realm.ts
@@ -1,6 +1,6 @@
 import { SecureEnvironment } from "./environment";
-import { RedProxyTarget, BlueFunction } from "./types";
-import { getOwnPropertyDescriptors, construct, ErrorCreate } from "./shared";
+import { RedProxyTarget } from "./types";
+import { getOwnPropertyDescriptors, remapToBlueError } from "./shared";
 import { runInNewContext } from 'vm';
 
 // note: in a node module, the top-level 'this' is not the global object
@@ -29,19 +29,7 @@ export default function createSecureEnvironment(distortionMap?: Map<RedProxyTarg
             // This error occurred when the blue realm attempts to evaluate a
             // sourceText into the sandbox. By throwing a new blue error, which
             // eliminates the stack information from the sandbox as a consequence.
-            let blueError;
-            const { message, constructor } = e;
-            try {
-                const blueErrorConstructor = env.getBlueValue(constructor);
-                // the constructor must be registered (done during construction of env)
-                // otherwise we need to fallback to a regular error.
-                blueError = construct(blueErrorConstructor as BlueFunction, [message]);
-            } catch {
-                // in case the constructor inference fails
-                blueError = ErrorCreate(message);
-            }
-            env.setRefMapEntries(e, blueError);
-            throw blueError;
+            throw remapToBlueError(env, e);
         }
     };
 }

--- a/src/red.ts
+++ b/src/red.ts
@@ -79,6 +79,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
         isSealed,
         isFrozen,
         hasOwnProperty,
+        prototype: ObjectPrototype
     } = Object;
     const ProxyRevocable = Proxy.revocable;
     const { isArray: isArrayOrNotOrThrowForRevoked } = Array;
@@ -112,6 +113,27 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
 
     function isNullOrUndefined(obj: any): obj is (null | undefined) {
         return isNull(obj) || isUndefined(obj);
+    }
+
+    function remapToRedError(env: MembraneBroker, blueError: BlueValue) {
+        let redError = env.getRedValue(blueError);
+        const { message, constructor } = redError;
+        const redErrorProto = getPrototypeOf(redError);
+        
+        if(redErrorProto === null || redErrorProto === ObjectPrototype) {
+            return redError;
+        }
+
+        try {                   
+            // the blue constructor must be registered (done during construction of env)
+            // otherwise we need to fallback to a regular error.
+            redError = construct(constructor as RedFunction, [message]);
+        } catch {
+            // in case the constructor inference fails
+            redError = ErrorCreate(message);
+        }
+        env.setRefMapEntries(redError, blueError);
+        return redError;
     }
 
     function isMarkAsDynamic(blue: RedProxyTarget): boolean {
@@ -308,21 +330,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
             // This error occurred when the sandbox attempts to call a
             // function from the blue realm. By throwing a new red error,
             // we eliminates the stack information from the blue realm as a consequence.
-            let redError;
-            const { message, constructor } = e;
-            try {
-                // the error constructor must be a blue error since it occur when calling
-                // a function from the blue realm.
-                const redErrorConstructor = blueEnv.getRedValue(constructor);
-                // the red constructor must be registered (done during construction of env)
-                // otherwise we need to fallback to a regular error.
-                redError = construct(redErrorConstructor as RedFunction, [message]);
-            } catch {
-                // in case the constructor inference fails
-                redError = new Error(message);
-            }
-            blueEnv.setRefMapEntries(redError, e);
-            throw redError;
+            throw remapToRedError(blueEnv, e);
         }
         return getRedValue(blue);
     }
@@ -341,21 +349,7 @@ export const serializedRedEnvSourceText = (function redEnvFactory(blueEnv: Membr
             // This error occurred when the sandbox attempts to new a
             // constructor from the blue realm. By throwing a new red error,
             // we eliminates the stack information from the blue realm as a consequence.
-            let redError;
-            const { message, constructor } = e;
-            try {
-                // the error constructor must be a blue error since it occur when calling
-                // a function from the blue realm.
-                const redErrorConstructor = blueEnv.getRedValue(constructor);
-                // the red constructor must be registered (done during construction of env)
-                // otherwise we need to fallback to a regular error.
-                redError = construct(redErrorConstructor as RedFunction, [message]);
-            } catch {
-                // in case the constructor inference fails
-                redError = new Error(message);
-            }
-            blueEnv.setRefMapEntries(redError, e);
-            throw redError;
+            throw remapToRedError(blueEnv, e);
         }
         return getRedValue(blue);
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -9,7 +9,6 @@ export const {
     seal,
     isSealed,
     isFrozen,
-    prototype: ObjectPrototype
 } = Object;
 
 export const {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,5 +1,3 @@
-import { RedValue, BlueFunction, MembraneBroker } from "./types";
-
 export const { isArray: ArrayIsArray } = Array;
 
 export const {
@@ -168,24 +166,3 @@ export const ReflectiveIntrinsicObjectNames = [
     'EvalError',
     'Error',
 ];
-
-export function remapToBlueError(env: MembraneBroker, redError: RedValue) {
-    let blueError = env.getBlueValue(redError);
-    const { message, constructor } = blueError;
-    const blueErrorProto = ReflectGetPrototypeOf(blueError);
-    
-    if(blueErrorProto === null || blueErrorProto === ObjectPrototype) {
-        return blueError;
-    }
-
-    try {                   
-        // the blue constructor must be registered (done during construction of env)
-        // otherwise we need to fallback to a regular error.
-        blueError = construct(constructor as BlueFunction, [message]);
-    } catch {
-        // in case the constructor inference fails
-        blueError = ErrorCreate(message);
-    }
-    env.setRefMapEntries(redError, blueError);
-    return blueError;
-}

--- a/test/membrane/error.spec.js
+++ b/test/membrane/error.spec.js
@@ -25,7 +25,7 @@ it('[red] non-error objects thrown in red constructors', () => {
         
         class Foo {
             constructor() {
-                throw errorObj;
+                throw errorObj
             }
         }
 
@@ -68,11 +68,11 @@ it('[red] unhandled promise rejections with non-error objects and red listener',
             done()
         }
         
-        window.addEventListener("unhandledrejection", handler);
+        window.addEventListener("unhandledrejection", handler)
 
         new Promise((resolve, reject) => {
             throw errorObj
-        });
+        })
     `)
 })
 
@@ -87,7 +87,7 @@ it('[red] Promise.reject non-error objects', (done) => {
             expect(e.message).toBe(undefined)
             expect(e.foo).toBe('bar')
             done()
-        });
+        })
     `)    
 })
 
@@ -104,7 +104,7 @@ it('[red] unhandled promise rejections and Promise.reject with non-error objects
             done()
         }
         
-        window.addEventListener("unhandledrejection", handler);
+        window.addEventListener("unhandledrejection", handler)
         new Promise((resolve, reject) => {
             reject(errorObj)
         })
@@ -159,7 +159,7 @@ it('[red] blue extended error objects', () => {
 
     class Foo {
         constructor() {
-            throw new CustomError('foo');
+            throw new CustomError('foo')
         }
     }
     
@@ -221,43 +221,79 @@ it('[red] non-error object with null proto from blue', () => {
     `)
 })
 
-// it('[red] blue promise non-error object thrown with red unhandled promise rejections listener', (done) => {
-//     new Promise(() => {
-//         throw {foo: 'bar'}
-//     })
+it('[red] instanceof Error', () => {
+    const evalScript = createSecureEnvironment(undefined, { expect })
+    evalScript(`
+        try {
+            throw new Error('foo')
+        } catch(e) {
+            expect(e instanceof Error).toBe(true)
+            expect(e.message).toBe('foo')
+        }
+    `)
+})
 
-//     let removeRedListener;
-//     function save(arg) {
-//         removeRedListener = arg;
-//     }
+it('[red] instanceof extended Error objects', () => {
+    const evalScript = createSecureEnvironment(undefined, { expect })
+    evalScript(`
+        class CustomError extends Error {}
+        try {
+            throw new CustomError('foo')
+        } catch(e) {
+            expect(e instanceof CustomError).toBe(true)
+            expect(e.message).toBe('foo')
+        }
+    `)
+})
 
-//     const evalScript = createSecureEnvironment(undefined, { expect, done, save })
-//     evalScript(`
-//         function handler() {
-//             // purposely not calling done so the test fails
-//             window.removeEventListener('unhandledrejection', handler);
-//         }
+it('[red] .catch instanceof Error', (done) => {
+    const evalScript = createSecureEnvironment(undefined, { done, expect })
+    evalScript(`
+        new Promise((resolve, reject) => {
+            reject(new Error('foo'))
+        }).catch(e => {
+            expect(e instanceof Error).toBe(true)
+            expect(e.message).toBe('foo')
+            done()
+        })
+    `)
+})
 
-//         save(handler)
-        
-//         window.addEventListener("unhandledrejection", handler);
-//     `)
+it('[red] instanceof blue Error objects', () => {
+    function foo() {
+        throw new Error('foo')
+    }
+    const evalScript = createSecureEnvironment(undefined, { foo, expect })
+    evalScript(`
+        try {
+            foo()
+        } catch(e) {
+            expect(e instanceof Error).toBe(true)
+            expect(e.message).toBe('foo')
+        }
+    `)
+})
 
-//     function handler(event) {
-//         expect(event.reason.foo).toBe(undefined)
-//         expect(event.reason.message).toBe(undefined)
-//         removeRedListener();
-//         done()
-//     }
-        
-//     window.addEventListener("unhandledrejection", handler);
-// })
+it('[red] .catch instanceof blue Error objects', (done) => {
+    const promise = new Promise((resolve, reject) => {
+        reject(new Error('foo'))
+    })
+
+    const evalScript = createSecureEnvironment(undefined, { promise, expect, done })
+    evalScript(`
+        promise.catch(e => {
+            expect(e instanceof Error).toBe(true)
+            expect(e.message).toBe('foo')
+            done()
+        })
+    `)
+})
 
 it('[blue] .catch on red promise', (done) => {
-    let promise;
+    let promise
 
     function save(arg) {
-        promise = arg;
+        promise = arg
     }
 
     const evalScript = createSecureEnvironment(undefined, { save })
@@ -267,7 +303,7 @@ it('[blue] .catch on red promise', (done) => {
             throw error
         })
         
-        save(p);
+        save(p)
     `)
 
     promise.catch((e) => {
@@ -281,18 +317,18 @@ it('[blue] unhandled promise rejections listener with red non-error objects', (d
     function handler(event) {
         expect(event.reason.foo).toBe('bar')
         expect(event.reason.message).toBe(undefined)
-        window.removeEventListener('unhandledrejection', handler);
+        window.removeEventListener('unhandledrejection', handler)
         done()
     }
 
-    window.addEventListener("unhandledrejection", handler);
+    window.addEventListener("unhandledrejection", handler)
 
     const evalScript = createSecureEnvironment(undefined, {})
     evalScript(`
         const errorObj = { foo: 'bar' }    
         new Promise((resolve, reject) => {
             throw errorObj
-        });
+        })
     `)
 })
 
@@ -307,14 +343,14 @@ it('[blue] non-error objects thrown in red functions', () => {
         function foo() {
             throw { foo: 'bar' }
         }
-        save(foo);
+        save(foo)
     `)
 
     try {
         fn()
     } catch(e) {
         expect(e.message).toBe(undefined)
-        expect(e.foo).toBe('bar');
+        expect(e.foo).toBe('bar')
     }
 })
 
@@ -331,7 +367,7 @@ it('[blue] non-error objects thrown in red consturctors', () => {
                 throw { foo: 'bar' }
             }
         }
-        save(Foo);
+        save(Foo)
     `)
 
     try {
@@ -363,7 +399,7 @@ it('[blue] red extended error objects', () => {
 
         class Foo {
             constructor() {
-                throw new CustomError('foo');
+                throw new CustomError('foo')
             }
         }
 
@@ -380,7 +416,7 @@ it('[blue] red extended error objects', () => {
 })
 
 it('[blue] non-error objects with null proto from red', () => {
-    let fn;
+    let fn
     function save(arg) {
         fn = arg
     }
@@ -388,7 +424,7 @@ it('[blue] non-error objects with null proto from red', () => {
     const evalScript = createSecureEnvironment(undefined, { save })
     evalScript(`
         function foo() {
-            const errorObj = Object.create(null, {foo: {value: 'bar'}});
+            const errorObj = Object.create(null, {foo: {value: 'bar'}})
             throw errorObj
         }
         
@@ -402,4 +438,49 @@ it('[blue] non-error objects with null proto from red', () => {
         expect(e.message).toBe(undefined)
         expect(e.foo).toBe('bar')
     }
+})
+
+it('[blue] instanceof red error', () => {
+    let fn
+    function save(arg) {
+        fn = arg
+    }
+
+    const evalScript = createSecureEnvironment(undefined, { save })
+    evalScript(`
+        function foo() {            
+            throw new Error('foo')
+        }
+        
+        save(foo)
+    `)
+
+    try {
+        fn()
+    } catch(e) {
+        expect(e instanceof Error).toBe(true)
+        expect(e.message).toBe('foo')
+    }
+})
+
+it('[blue] .catch instanceof red error', (done) => {
+    let promise
+    function save(arg) {
+        promise = arg
+    }
+
+    const evalScript = createSecureEnvironment(undefined, { save })
+    evalScript(`
+        const promise = new Promise((resolve, reject) => {
+            reject(new Error('foo'))
+        })
+        
+        save(promise)
+    `)
+
+    promise.catch(e => {
+        expect(e instanceof Error).toBe(true)
+        expect(e.message).toBe('foo')
+        done()
+    })
 })

--- a/test/membrane/error.spec.js
+++ b/test/membrane/error.spec.js
@@ -1,6 +1,6 @@
 import createSecureEnvironment from '../../lib/browser-realm.js'
 
-it('non-error objects thrown in red functions', () => {
+it('[red] non-error objects thrown in red functions', () => {
     const evalScript = createSecureEnvironment(undefined, { expect })
     evalScript(`
         const errorObj = { foo: 'bar' }
@@ -18,7 +18,7 @@ it('non-error objects thrown in red functions', () => {
     `)
 })
 
-it('non-error objects thrown in red constructors', () => {
+it('[red] non-error objects thrown in red constructors', () => {
     const evalScript = createSecureEnvironment(undefined, { expect })
     evalScript(`
         const errorObj = { foo: 'bar' }
@@ -39,7 +39,7 @@ it('non-error objects thrown in red constructors', () => {
     `)
 })
 
-it('non-error objects thrown in Promise', (done) => {
+it('[red] non-error objects thrown in Promise', (done) => {
     const evalScript = createSecureEnvironment(undefined, { done, expect })
     evalScript(`
         const error = { foo: 'bar' }
@@ -55,31 +55,7 @@ it('non-error objects thrown in Promise', (done) => {
     `)
 })
 
-it('non-error objects thrown in Promise handled in blue', (done) => {
-    let promise;
-
-    function save(arg) {
-        promise = arg;
-    }
-
-    const evalScript = createSecureEnvironment(undefined, { save })
-    evalScript(`
-        const error = { foo: 'bar' }
-        const p = new Promise(() => {
-            throw error
-        })
-        
-        save(p);
-    `)
-
-    promise.catch((e) => {
-        expect(e.foo).toBe(undefined)
-        expect(e.message).toBe(undefined)
-        done()
-    })
-})
-
-it('unhandled promise rejections with non-error objects', (done) => {
+it('[red] unhandled promise rejections with non-error objects and red listener', (done) => {
     const evalScript = createSecureEnvironment(undefined, { done, expect })
     evalScript(`
         const errorObj = { foo: 'bar' }
@@ -100,26 +76,42 @@ it('unhandled promise rejections with non-error objects', (done) => {
     `)
 })
 
-it('unhandled promise rejections with non-error objects handled in blue', (done) => {
-    function handler(event) {
-        expect(event.reason.foo === undefined).toBe(true)
-        expect(event.reason.message === undefined).toBe(true)
-        window.removeEventListener('unhandledrejection', handler);
-        done()
-    }
-
-    window.addEventListener("unhandledrejection", handler);
-
-    const evalScript = createSecureEnvironment(undefined, {})
+it('[red] Promise.reject non-error objects', (done) => {
+    const evalScript = createSecureEnvironment(undefined, { done, expect })
     evalScript(`
-        const errorObj = { foo: 'bar' }    
+        const errorObj = { foo: 'bar' }
+
         new Promise((resolve, reject) => {
-            throw errorObj
+            reject(errorObj)
+        }).catch(e => {
+            expect(e.message).toBe(undefined)
+            expect(e.foo).toBe('bar')
+            done()
         });
+    `)    
+})
+
+it('[red] unhandled promise rejections and Promise.reject with non-error objects and red listener', (done) => {
+    const evalScript = createSecureEnvironment(undefined, { done, expect })
+    evalScript(`
+        const errorObj = { foo: 'bar' }
+
+        function handler(event) {
+            expect(event.reason).toBe(errorObj)
+            expect(event.reason.foo).toBe('bar')
+            expect(event.reason.message).toBe(undefined)
+            window.removeEventListener('unhandledrejection', handler)
+            done()
+        }
+        
+        window.addEventListener("unhandledrejection", handler);
+        new Promise((resolve, reject) => {
+            reject(errorObj)
+        })
     `)
 })
 
-it('non-error objects thrown in blue functions do not leak', () => {
+it('[red] non-error objects thrown in blue functions', () => {
     function foo() {
         throw { foo: 'bar' }
     }
@@ -129,14 +121,13 @@ it('non-error objects thrown in blue functions do not leak', () => {
         try {
             foo()
         } catch (e) {
-            // blue error own properties do not leak in red
             expect(e.message).toBe(undefined)
-            expect(e.foo).toBe(undefined)
+            expect(e.foo).toBe('bar')
         }
     `)
 })
 
-it('non-error objects thrown in blue constructors do not leak', () => {
+it('[red] non-error objects thrown in blue constructors', () => {
     class Foo {
         constructor() {
             throw { foo: 'bar' }
@@ -148,60 +139,13 @@ it('non-error objects thrown in blue constructors do not leak', () => {
         try {
             new Foo()
         } catch (e) {
-            // blue error own properties on thrown object do not leak
             expect(e.message).toBe(undefined)
-            expect(e.foo).toBe(undefined)
+            expect(e.foo).toBe('bar')
         }
     `)
 })
 
-it('non-error objects thrown in red functions do not leak', () => {
-    let fn
-    function save(arg) {
-        fn = arg
-    }
-
-    const evalScript = createSecureEnvironment(undefined, { save })
-    evalScript(`
-        function foo() {
-            throw { foo: 'bar' }
-        }
-        save(foo);
-    `)
-
-    try {
-        fn()
-    } catch(e) {
-        expect(e.message).toBe(undefined)
-        expect(e.foo).toBe(undefined);
-    }
-})
-
-it('non-error objects thrown in red consturctors do not leak', () => {
-    let ctor
-    function save(arg) {
-        ctor = arg
-    }
-
-    const evalScript = createSecureEnvironment(undefined, { save })
-    evalScript(`
-        class Foo {
-            constructor() {
-                throw { foo: 'bar' }
-            }
-        }
-        save(Foo);
-    `)
-
-    try {
-        new ctor()
-    } catch(e) {
-        expect(e.message).toBe(undefined)
-        expect(e.foo).toBe(undefined)
-    }
-})
-
-it('blue extended error objects preserve properties', () => {
+it('[red] blue extended error objects', () => {
     class CustomError extends Error {
         constructor(message) {
             super(message)
@@ -229,10 +173,176 @@ it('blue extended error objects preserve properties', () => {
             expect(e.message).toBe('foo')
         }
     `)
-
 })
 
-it('red extended error objects to blue side', () => {
+it('[red] .catch on blue promise', (done) => {
+    const promise = new Promise(() => {
+        throw {foo: 'bar'}
+    })
+
+    const evalScript = createSecureEnvironment(undefined, { promise, expect, done })
+    evalScript(`
+        promise.catch(e => {
+            expect(e.foo).toBe('bar')
+            expect(e.message).toBe(undefined)
+            done()
+        })
+    `)
+})
+
+it('[red] non-error object with null proto', () => {
+    const evalScript = createSecureEnvironment(undefined, { expect })
+    evalScript(`
+        const errorObj = Object.create(null, {foo: {value: 'bar'}})
+        try {
+            throw errorObj
+        } catch(e) {
+            expect(errorObj).toBe(errorObj)
+            expect(Reflect.getPrototypeOf(errorObj)).toBe(null)
+            expect(errorObj.message).toBe(undefined)
+            expect(errorObj.foo).toBe('bar')
+        }
+    `)
+})
+
+it('[red] non-error object with null proto from blue', () => {
+    function foo() {
+        throw Object.create(null, {foo: {value: 'bar'}})
+    }
+    const evalScript = createSecureEnvironment(undefined, { foo, expect })
+    evalScript(`
+        try {
+            foo()
+        } catch(e) {
+            expect(Reflect.getPrototypeOf(e)).toBe(null)
+            expect(e.message).toBe(undefined)
+            expect(e.foo).toBe('bar')
+        }
+    `)
+})
+
+// it('[red] blue promise non-error object thrown with red unhandled promise rejections listener', (done) => {
+//     new Promise(() => {
+//         throw {foo: 'bar'}
+//     })
+
+//     let removeRedListener;
+//     function save(arg) {
+//         removeRedListener = arg;
+//     }
+
+//     const evalScript = createSecureEnvironment(undefined, { expect, done, save })
+//     evalScript(`
+//         function handler() {
+//             // purposely not calling done so the test fails
+//             window.removeEventListener('unhandledrejection', handler);
+//         }
+
+//         save(handler)
+        
+//         window.addEventListener("unhandledrejection", handler);
+//     `)
+
+//     function handler(event) {
+//         expect(event.reason.foo).toBe(undefined)
+//         expect(event.reason.message).toBe(undefined)
+//         removeRedListener();
+//         done()
+//     }
+        
+//     window.addEventListener("unhandledrejection", handler);
+// })
+
+it('[blue] .catch on red promise', (done) => {
+    let promise;
+
+    function save(arg) {
+        promise = arg;
+    }
+
+    const evalScript = createSecureEnvironment(undefined, { save })
+    evalScript(`
+        const error = { foo: 'bar' }
+        const p = new Promise(() => {
+            throw error
+        })
+        
+        save(p);
+    `)
+
+    promise.catch((e) => {
+        expect(e.foo).toBe('bar')
+        expect(e.message).toBe(undefined)
+        done()
+    })
+})
+
+it('[blue] unhandled promise rejections listener with red non-error objects', (done) => {
+    function handler(event) {
+        expect(event.reason.foo).toBe('bar')
+        expect(event.reason.message).toBe(undefined)
+        window.removeEventListener('unhandledrejection', handler);
+        done()
+    }
+
+    window.addEventListener("unhandledrejection", handler);
+
+    const evalScript = createSecureEnvironment(undefined, {})
+    evalScript(`
+        const errorObj = { foo: 'bar' }    
+        new Promise((resolve, reject) => {
+            throw errorObj
+        });
+    `)
+})
+
+it('[blue] non-error objects thrown in red functions', () => {
+    let fn
+    function save(arg) {
+        fn = arg
+    }
+
+    const evalScript = createSecureEnvironment(undefined, { save })
+    evalScript(`
+        function foo() {
+            throw { foo: 'bar' }
+        }
+        save(foo);
+    `)
+
+    try {
+        fn()
+    } catch(e) {
+        expect(e.message).toBe(undefined)
+        expect(e.foo).toBe('bar');
+    }
+})
+
+it('[blue] non-error objects thrown in red consturctors', () => {
+    let ctor
+    function save(arg) {
+        ctor = arg
+    }
+
+    const evalScript = createSecureEnvironment(undefined, { save })
+    evalScript(`
+        class Foo {
+            constructor() {
+                throw { foo: 'bar' }
+            }
+        }
+        save(Foo);
+    `)
+
+    try {
+        new ctor()
+    } catch(e) {
+        expect(e.message).toBe(undefined)
+        expect(e.foo).toBe('bar')
+    }
+})
+
+it('[blue] red extended error objects', () => {
     let ctor
     function save(arg) {
         ctor = arg
@@ -265,6 +375,31 @@ it('red extended error objects to blue side', () => {
     } catch(e) {
         expect(e.message).toBe('foo')
         expect(e.bar).toBe('baz')
+        expect(e.foo).toBe('bar')
+    }
+})
+
+it('[blue] non-error objects with null proto from red', () => {
+    let fn;
+    function save(arg) {
+        fn = arg
+    }
+
+    const evalScript = createSecureEnvironment(undefined, { save })
+    evalScript(`
+        function foo() {
+            const errorObj = Object.create(null, {foo: {value: 'bar'}});
+            throw errorObj
+        }
+        
+        save(foo)
+    `)
+
+    try {
+        fn()
+    } catch(e) {
+        expect(Reflect.getPrototypeOf(e)).toBe(null)
+        expect(e.message).toBe(undefined)
         expect(e.foo).toBe('bar')
     }
 })


### PR DESCRIPTION
A discrepancy in the behavior of errors in Promises lead to the following refactor. See below
```
// in red:

promise1 = new Promise(() => { throw {foo: 'bar' })
promise2 = new Promise((resolve, reject) => reject({foo: 'bar'}))

// in blue
promise1.catch(e => console.log(e.foo)) // undefined
promise2.catch(e => console.log(e.foo)) // bar
```


This inconsistency led to a deeper analysis of how errors were handled previously and the need to align the behavior in both promises but also functions and constructors. 